### PR TITLE
refactor(backend): use dash instead of underscore for package and binary name

### DIFF
--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -46,17 +46,17 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-amd64
-          path: src/backend/target/release/dietpi_dashboard
+          path: src/backend/target/release/dietpi-dashboard
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-armv6
-          path: src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi_dashboard
+          path: src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi-dashboard
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-armv7
-          path: src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi_dashboard
+          path: src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi-dashboard
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-armv8
-          path: src/backend/target/aarch64-unknown-linux-gnu/release/dietpi_dashboard
+          path: src/backend/target/aarch64-unknown-linux-gnu/release/dietpi-dashboard
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default: yarn publiccopy fmt
 
 	$(MAKE) publicdelete
 
-	mv src/backend/target/debug/dietpi_dashboard ./dietpi-dashboard
+	mv src/backend/target/debug/dietpi-dashboard ./dietpi-dashboard
 
 rust: publiccopy fmt 
 
@@ -12,7 +12,7 @@ rust: publiccopy fmt
 
 	$(MAKE) publicdelete
 
-	mv src/backend/target/debug/dietpi_dashboard ./dietpi-dashboard
+	mv src/backend/target/debug/dietpi-dashboard ./dietpi-dashboard
 
 yarn:
 	cd src/frontend; yarn build
@@ -29,7 +29,7 @@ fmt:
 
 rustdev: publiccopy fmt
 	cd src/backend; cargo build --target $(TARGET)
-	mv src/backend/target/$(TARGET)/debug/dietpi_dashboard ./dietpi-dashboard
+	mv src/backend/target/$(TARGET)/debug/dietpi-dashboard ./dietpi-dashboard
 
 	$(MAKE) publicdelete
 
@@ -39,24 +39,24 @@ rustbuild: publiccopy fmt
 	mkdir -p build/
 
 	cd src/backend; cargo build --release --target x86_64-unknown-linux-gnu
-	x86_64-linux-gnu-strip src/backend/target/x86_64-unknown-linux-gnu/release/dietpi_dashboard
-	upx-ucl --lzma src/backend/target/x86_64-unknown-linux-gnu/release/dietpi_dashboard
-	mv src/backend/target/x86_64-unknown-linux-gnu/release/dietpi_dashboard build/dietpi-dashboard-amd64
+	x86_64-linux-gnu-strip src/backend/target/x86_64-unknown-linux-gnu/release/dietpi-dashboard
+	upx-ucl --lzma src/backend/target/x86_64-unknown-linux-gnu/release/dietpi-dashboard
+	mv src/backend/target/x86_64-unknown-linux-gnu/release/dietpi-dashboard build/dietpi-dashboard-amd64
 
 	cd src/backend; cargo build --release --target arm-unknown-linux-gnueabihf
-	/opt/rpi/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-strip src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi_dashboard
-	upx --lzma src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi_dashboard
-	mv src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi_dashboard build/dietpi-dashboard-armv6
+	/opt/rpi/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-strip src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi-dashboard
+	upx --lzma src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi-dashboard
+	mv src/backend/target/arm-unknown-linux-gnueabihf/release/dietpi-dashboard build/dietpi-dashboard-armv6
 
 	cd src/backend; cargo build --release --target armv7-unknown-linux-gnueabihf
-	arm-linux-gnueabihf-strip src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi_dashboard
-	upx --lzma src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi_dashboard
-	mv src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi_dashboard build/dietpi-dashboard-armv7
+	arm-linux-gnueabihf-strip src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi-dashboard
+	upx --lzma src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi-dashboard
+	mv src/backend/target/armv7-unknown-linux-gnueabihf/release/dietpi-dashboard build/dietpi-dashboard-armv7
 
 	cd src/backend; cargo build --release --target aarch64-unknown-linux-gnu
-	aarch64-linux-gnu-strip src/backend/target/aarch64-unknown-linux-gnu/release/dietpi_dashboard
-	upx-ucl --lzma src/backend/target/aarch64-unknown-linux-gnu/release/dietpi_dashboard
-	mv src/backend/target/aarch64-unknown-linux-gnu/release/dietpi_dashboard build/dietpi-dashboard-armv8
+	aarch64-linux-gnu-strip src/backend/target/aarch64-unknown-linux-gnu/release/dietpi-dashboard
+	upx-ucl --lzma src/backend/target/aarch64-unknown-linux-gnu/release/dietpi-dashboard
+	mv src/backend/target/aarch64-unknown-linux-gnu/release/dietpi-dashboard build/dietpi-dashboard-armv8
 
 	$(MAKE) publicdelete
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ fi
 curl -L "https://nightly.link/ravenclaw900/DietPi-Dashboard/workflows/push-build/main/dietpi-dashboard-$dpdashboardarch.zip" -o dietpi-dashboard.zip # Download latest nightly build for current architecture
 unzip dietpi-dashboard.zip # Unzip binary
 unset dpdashboardarch # Remove architecture variable
-chmod +x dietpi_dashboard # Make binary exectuable
-./dietpi_dashboard # Run binary
+chmod +x dietpi-dashboard # Make binary exectuable
+./dietpi-dashboard # Run binary
 ```
 
 

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "dietpi_dashboard"
+name = "dietpi-dashboard"
 version = "0.3.0"
 dependencies = [
  "futures",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dietpi_dashboard"
+name = "dietpi-dashboard"
 version = "0.3.0"
 edition = "2018"
 


### PR DESCRIPTION
I hope I replaced all relevant cases. Generally dashes in names seem to be okay, though I found a case where it caused issues: https://github.com/rust-lang/cargo/issues/10035

This is to avoid an additional `mv` step when extracting e.g. the nightly archive and to have consistent binary names.

Not sure why it is not shown here, but the build action runs on my fork: https://github.com/MichaIng/DietPi-Dashboard/runs/4126674557?check_suite_focus=true