### PR TITLE
fix(frontend): change table header text color from white to black

### DIFF
--- a/src/frontend/src/pages/Process.svelte
+++ b/src/frontend/src/pages/Process.svelte
@@ -232,7 +232,7 @@
         <table
             class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words overflow-x-scroll"
         >
-            <tr class="bg-dplime" style="color:#000">
+            <tr class="table-header">
                 <th
                     >PID<span on:click={setPid}
                         ><Fa

--- a/src/frontend/src/pages/Process.svelte
+++ b/src/frontend/src/pages/Process.svelte
@@ -232,7 +232,7 @@
         <table
             class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words overflow-x-scroll"
         >
-            <tr class="bg-dplime">
+            <tr class="bg-dplime" style="color:#000">
                 <th
                     >PID<span on:click={setPid}
                         ><Fa

--- a/src/frontend/src/pages/Service.svelte
+++ b/src/frontend/src/pages/Service.svelte
@@ -30,7 +30,7 @@
         <table
             class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
         >
-            <tr class="bg-dplime" style="color:#000">
+            <tr class="table-header">
                 <th>Name</th>
                 <th>Status</th>
                 <th>Error Log</th>

--- a/src/frontend/src/pages/Service.svelte
+++ b/src/frontend/src/pages/Service.svelte
@@ -30,7 +30,7 @@
         <table
             class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
         >
-            <tr class="bg-dplime">
+            <tr class="bg-dplime" style="color:#000">
                 <th>Name</th>
                 <th>Status</th>
                 <th>Error Log</th>

--- a/src/frontend/src/pages/Software.svelte
+++ b/src/frontend/src/pages/Software.svelte
@@ -95,7 +95,7 @@
         <table
             class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
         >
-            <tr class="bg-dplime" style="color:#000">
+            <tr class="table-header">
                 <th>ID</th>
                 <th>Installed</th>
                 <th>Name</th>

--- a/src/frontend/src/pages/Software.svelte
+++ b/src/frontend/src/pages/Software.svelte
@@ -95,7 +95,7 @@
         <table
             class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
         >
-            <tr class="bg-dplime">
+            <tr class="bg-dplime" style="color:#000">
                 <th>ID</th>
                 <th>Installed</th>
                 <th>Name</th>

--- a/src/frontend/windi.config.ts
+++ b/src/frontend/windi.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         },
     },
     shortcuts: {
-        "btn": "hover:bg-gray-500/50 active:bg-opacity-75"
+        "btn": "hover:bg-gray-500/50 active:bg-opacity-75",
+        "table-header": "bg-dplime text-black"
     },
 })


### PR DESCRIPTION
Would be certainly nicer to add this style via classes, e.g. bind it to the `bg-dplime` class as white text on this background never looks good. However, the class seems auto-generated so until someone knows an elegant solution, here the quick & dirty one 😉.

Fixes #16