### PR TITLE
Use hardcoded bash for terminal instead of $SHELL

### DIFF
--- a/src/backend/src/terminal.rs
+++ b/src/backend/src/terminal.rs
@@ -19,7 +19,8 @@ pub async fn term_handler(socket: warp::ws::WebSocket) {
     let (mut socket_send, mut socket_recv) = socket.split();
 
     let cmd = Arc::new(RwLock::new(
-        std::process::Command::new(std::env::var_os("SHELL").unwrap())
+        // Use hardcoded bash here until we have better support for other shells
+        std::process::Command::new("/bin/bash")
             .spawn_pty(None)
             .unwrap(),
     ));


### PR DESCRIPTION
since the SHELL variable is not necessarily set, e.g. not by default in systemd units. Also in systemd units with a defined user it is not set to the users default shell but to "/bin/sh" instead. And finally our aliases and login scripts only run fully as intended in bash.