### PR TITLE
ci(build): add rustfmt and clippy lint steps

### DIFF
--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo fmt -- --check
       - name: Lint (clippy)
         working-directory: src/backend
-        run: cargo clippy --all-targets --all-feature -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v1
         with:

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -21,8 +21,10 @@ jobs:
           rustup target add armv7-unknown-linux-musleabihf
           rustup target add aarch64-unknown-linux-musl
       - name: Lint (rustfmt)
-        run: cargo fmt --all -- --check
+        working-directory: src/backend
+        run: cargo fmt -- --check
       - name: Lint (clippy)
+        working-directory: src/backend
         run: cargo clippy --all-targets --all-feature -- -D warnings
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -13,12 +13,17 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          components: rustfmt, clippy
       - name: Install other Rust targets
         run: |
           rustup target add x86_64-unknown-linux-musl
           rustup target add arm-unknown-linux-musleabihf
           rustup target add armv7-unknown-linux-musleabihf
           rustup target add aarch64-unknown-linux-musl
+      - name: Lint (rustfmt)
+        run: cargo fmt --all -- --check
+      - name: Lint (clippy)
+        run: cargo clippy --all-targets --all-feature -- -D warnings
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v1
         with:

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -14,18 +14,15 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      - name: Lint (rustfmt)
+        working-directory: src/backend
+        run: cargo fmt -- --check
       - name: Install other Rust targets
         run: |
           rustup target add x86_64-unknown-linux-musl
           rustup target add arm-unknown-linux-musleabihf
           rustup target add armv7-unknown-linux-musleabihf
           rustup target add aarch64-unknown-linux-musl
-      - name: Lint (rustfmt)
-        working-directory: src/backend
-        run: cargo fmt -- --check
-      - name: Lint (clippy)
-        working-directory: src/backend
-        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v1
         with:
@@ -40,6 +37,9 @@ jobs:
         run: yarn build
       - name: Copy "dist" folder
         run: cp -r src/frontend/dist src/backend
+      - name: Lint (clippy)
+        working-directory: src/backend
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Build amd64
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -27,8 +27,11 @@ jobs:
         uses: Swatinem/rust-cache@v1
         with:
           working-directory: src/backend
-      - name: Install Rust cross-compiler
-        run: cargo install cross
+      - name: Lint (clippy)
+        working-directory: src/backend
+        run: |
+          mkdir dist
+          cargo clippy --all-targets --all-features -- -D warnings
       - name: Install Yarn Dependencies
         working-directory: src/frontend
         run: yarn install
@@ -36,10 +39,7 @@ jobs:
         working-directory: src/frontend
         run: yarn build
       - name: Copy "dist" folder
-        run: cp -r src/frontend/dist src/backend
-      - name: Lint (clippy)
-        working-directory: src/backend
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cp -r src/frontend/dist/. src/backend/dist/
       - name: Build amd64
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl


### PR DESCRIPTION
Better now than later 😄. CodeFactor seems to not support Rust code, but it has its internal lint tools which we can use.