### PR TITLE
feat(frontend): allow clicking 'Enter' to send passwords

### DIFF
--- a/src/frontend/src/App.svelte
+++ b/src/frontend/src/App.svelte
@@ -238,13 +238,6 @@
         );
     }
 
-    function onPasswordEnter(e: KeyboardEvent) {
-        // when enter key pressed
-        if (e.key == 'Enter') {
-            getToken();
-        }
-    }
-
     function socketSend(cmd: string, args: string[]) {
         let json;
         if (login) {
@@ -287,17 +280,19 @@
                 class="bg-white dark:bg-black w-1/2 h-1/3 rounded-md flex items-center flex-col justify-center text-xl z-40 gap-5 dark:text-white"
             >
                 <h6>Please login:</h6>
-                <input
-                    type="password"
-                    class="outline-none bg-gray-100 border border-gray-400 dark:border-gray-700 rounded focus:bg-gray-200 dark:bg-gray-900 dark:focus:bg-gray-800"
-                    on:keypress="{onPasswordEnter}"
-                    bind:value={password}
-                />
-                <button
-                    on:click={getToken}
-                    class="border-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 focus:outline-none border p-2 rounded active:bg-gray-200 dark:active:bg-gray-800"
-                    >Login</button
+                <form
+                    on:submit|preventDefault="{getToken}"
                 >
+                    <input
+                        type="password"
+                        class="outline-none bg-gray-100 border border-gray-400 dark:border-gray-700 rounded focus:bg-gray-200 dark:bg-gray-900 dark:focus:bg-gray-800"
+                        bind:value={password}
+                    />
+                    <button
+                        type="submit"
+                        class="border-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 focus:outline-none border p-2 rounded active:bg-gray-200 dark:active:bg-gray-800"
+                    >Login</button>
+                </form> 
                 {#if passwordMessage}
                     <h6 class="text-red-500" transition:fade>
                         Incorrect password

--- a/src/frontend/src/App.svelte
+++ b/src/frontend/src/App.svelte
@@ -123,8 +123,7 @@
     let login = false;
     let loginDialog = false;
     let nodes: string[] = [];
-    // let node = `${window.location.hostname}:${window.location.port}`;
-    let node = "172.16.1.16:5252"
+    let node = `${window.location.hostname}:${window.location.port}`;
     let notificationsShown = false;
     let settingsShown = false;
     let passwordMessage = false;
@@ -275,7 +274,7 @@
         socket.onerror = socketErrorListener;
     }
 
-    $: node && ((shown = false), connectSocket("172.16.1.16:5252"));
+    $: node && ((shown = false), connectSocket(node));
 </script>
 
 <main class="min-h-screen flex overflow-x-hidden{darkMode ? ' dark' : ''}">

--- a/src/frontend/src/App.svelte
+++ b/src/frontend/src/App.svelte
@@ -280,8 +280,8 @@
                 class="bg-white dark:bg-black w-1/2 h-1/3 rounded-md flex items-center flex-col justify-center text-xl z-40 gap-5 dark:text-white"
             >
                 <h6>Please login:</h6>
-                <form
-                    on:submit|preventDefault="{getToken}"
+                <form class="flex flex-col gap-5 items-center"
+                    on:submit|preventDefault={getToken}
                 >
                     <input
                         type="password"

--- a/src/frontend/src/App.svelte
+++ b/src/frontend/src/App.svelte
@@ -123,7 +123,8 @@
     let login = false;
     let loginDialog = false;
     let nodes: string[] = [];
-    let node = `${window.location.hostname}:${window.location.port}`;
+    // let node = `${window.location.hostname}:${window.location.port}`;
+    let node = "172.16.1.16:5252"
     let notificationsShown = false;
     let settingsShown = false;
     let passwordMessage = false;
@@ -238,6 +239,13 @@
         );
     }
 
+    function onPasswordEnter(e: KeyboardEvent) {
+        // when enter key pressed
+        if (e.key == 'Enter') {
+            getToken();
+        }
+    }
+
     function socketSend(cmd: string, args: string[]) {
         let json;
         if (login) {
@@ -267,7 +275,7 @@
         socket.onerror = socketErrorListener;
     }
 
-    $: node && ((shown = false), connectSocket(node));
+    $: node && ((shown = false), connectSocket("172.16.1.16:5252"));
 </script>
 
 <main class="min-h-screen flex overflow-x-hidden{darkMode ? ' dark' : ''}">
@@ -283,6 +291,7 @@
                 <input
                     type="password"
                     class="outline-none bg-gray-100 border border-gray-400 dark:border-gray-700 rounded focus:bg-gray-200 dark:bg-gray-900 dark:focus:bg-gray-800"
+                    on:keypress="{onPasswordEnter}"
                     bind:value={password}
                 />
                 <button


### PR DESCRIPTION
Added a keypress handler to the initial password input field so that a user can simply press `Enter` to get into their dashboard instead of clicking on the "Login" button.