### PR TITLE
ci(dependabot): Approve and merge non-major bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PR
+        run: gh pr review --approve "${{ github.event.pull_request.html_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for non-major update PR
+        if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Based on the GitHub documentation: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#approve-a-pull-request

The GitHub CLI docs can be found here: https://cli.github.com/manual/gh_pr

It may require to enable R/W permissions for `GITHUB_TOKEN` (can be changed in Actions settings), in case the `permissions:` in the workflow do not override it anyway.

Safes us some time to  get those merged. Excluding major updates which we may want to review first. Minor and patch version updates are not expected to cause issues, otherwise should fail other tests. In case an update allows to remove some workaround or do an enhancement elsewhere in the code, we are notified about the merge anyway and can review the changelog.