### PR TITLE
feat(backend): allow to set log level via config file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,11 +1,18 @@
+# Log level
+# - Options: "off", "error", "warn", "info", "debug", "trace"
+# - Default: "info"
+#loglevel = "info"
+
 # TCP network port
 # - Default: 5252
 #port = 5252
+
 # TLS for HTTPS
 # - Default: false
 #tls = false
 #cert = "/path/to/cert"
 #key = "/path/to/key"
+
 # Password protection
 # - Default: false
 #pass = false
@@ -16,6 +23,7 @@
 # Token expiry time in seconds
 # - Default: 3600
 #expiry = 3600
+
 # Other nodes viewable on frontend page
 # - Default: []
 # Please insert the IP addresses/domains and ports of these nodes

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 # Log level
 # - Options: "off", "error", "warn", "info", "debug", "trace"
 # - Default: "info"
-#loglevel = "info"
+#log_level = "info"
 
 # TCP network port
 # - Default: 5252

--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -1,6 +1,8 @@
 use toml::Value;
 
 pub struct Config {
+    pub loglevel: String,
+
     pub port: u16,
 
     pub tls: bool,
@@ -31,6 +33,12 @@ pub fn config() -> Config {
     }
     .parse::<Value>()
     .expect("Invalid config file");
+
+    let loglevel = std::env::var("RUST_LOG").unwrap_or_else(|_| {
+        cfg.get("loglevel")
+            .to_string()
+            .unwrap_or_else(|| String::from("info"))
+    });
 
     #[allow(clippy::cast_sign_loss)]
     #[allow(clippy::cast_possible_truncation)]
@@ -106,6 +114,7 @@ pub fn config() -> Config {
     }
 
     Config {
+        loglevel,
         port,
         tls,
         cert,

--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -37,7 +37,7 @@ pub fn config() -> Config {
 
     let loglevel = log::LevelFilter::from_str(
         cfg.get("loglevel")
-            .unwrap_or(&Value::String("info".to_string()))
+            .unwrap_or_else(|| &Value::String("info".to_string()))
             .as_str()
             .unwrap(),
     )
@@ -47,13 +47,13 @@ pub fn config() -> Config {
     #[allow(clippy::cast_possible_truncation)]
     let port: u16 = cfg
         .get("port")
-        .unwrap_or(&Value::Integer(5252))
+        .unwrap_or_else(|| &Value::Integer(5252))
         .as_integer()
         .unwrap() as u16;
 
     let tls = cfg
         .get("tls")
-        .unwrap_or(&Value::Boolean(false))
+        .unwrap_or_else(|| &Value::Boolean(false))
         .as_bool()
         .unwrap();
     let mut cert = String::new();
@@ -61,13 +61,13 @@ pub fn config() -> Config {
     if tls {
         cert = cfg
             .get("cert")
-            .unwrap_or(&Value::String(String::new()))
+            .unwrap_or_else(|| &Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
         key = cfg
             .get("key")
-            .unwrap_or(&Value::String(String::new()))
+            .unwrap_or_else(|| &Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
@@ -75,7 +75,7 @@ pub fn config() -> Config {
 
     let pass = cfg
         .get("pass")
-        .unwrap_or(&Value::Boolean(false))
+        .unwrap_or_else(|| &Value::Boolean(false))
         .as_bool()
         .unwrap();
 
@@ -84,13 +84,13 @@ pub fn config() -> Config {
     if pass {
         hash = cfg
             .get("hash")
-            .unwrap_or(&Value::String(String::new()))
+            .unwrap_or_else(|| &Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
         secret = cfg
             .get("secret")
-            .unwrap_or(&Value::String(String::new()))
+            .unwrap_or_else(|| &Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
@@ -99,7 +99,7 @@ pub fn config() -> Config {
     #[allow(clippy::cast_sign_loss)]
     let expiry = cfg
         .get("expiry")
-        .unwrap_or(&Value::Integer(3600))
+        .unwrap_or_else(|| &Value::Integer(3600))
         .as_integer()
         .unwrap() as u64;
 
@@ -109,7 +109,7 @@ pub fn config() -> Config {
     #[cfg(feature = "frontend")]
     for i in cfg
         .get("nodes")
-        .unwrap_or(&Value::Array(Vec::new()))
+        .unwrap_or_else(|| &Value::Array(Vec::new()))
         .as_array()
         .unwrap()
     {

--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -1,7 +1,8 @@
+use std::str::FromStr;
 use toml::Value;
 
 pub struct Config {
-    pub loglevel: String,
+    pub loglevel: log::LevelFilter,
 
     pub port: u16,
 
@@ -34,11 +35,13 @@ pub fn config() -> Config {
     .parse::<Value>()
     .expect("Invalid config file");
 
-    let loglevel = std::env::var("RUST_LOG").unwrap_or_else(|_| {
+    let loglevel = log::LevelFilter::from_str(
         cfg.get("loglevel")
-            .to_string()
-            .unwrap_or_else(|| String::from("info"))
-    });
+            .unwrap_or(&Value::String("info".to_string()))
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
 
     #[allow(clippy::cast_sign_loss)]
     #[allow(clippy::cast_possible_truncation)]

--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use toml::Value;
 
 pub struct Config {
-    pub loglevel: log::LevelFilter,
+    pub log_level: log::LevelFilter,
 
     pub port: u16,
 
@@ -35,8 +35,8 @@ pub fn config() -> Config {
     .parse::<Value>()
     .expect("Invalid config file");
 
-    let loglevel = log::LevelFilter::from_str(
-        cfg.get("loglevel")
+    let log_level = log::LevelFilter::from_str(
+        cfg.get("log_level")
             .unwrap_or(&Value::String("info".to_string()))
             .as_str()
             .unwrap(),
@@ -117,7 +117,7 @@ pub fn config() -> Config {
     }
 
     Config {
-        loglevel,
+        log_level,
         port,
         tls,
         cert,

--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -37,7 +37,7 @@ pub fn config() -> Config {
 
     let loglevel = log::LevelFilter::from_str(
         cfg.get("loglevel")
-            .unwrap_or_else(|| &Value::String("info".to_string()))
+            .unwrap_or(&Value::String("info".to_string()))
             .as_str()
             .unwrap(),
     )
@@ -47,13 +47,13 @@ pub fn config() -> Config {
     #[allow(clippy::cast_possible_truncation)]
     let port: u16 = cfg
         .get("port")
-        .unwrap_or_else(|| &Value::Integer(5252))
+        .unwrap_or(&Value::Integer(5252))
         .as_integer()
         .unwrap() as u16;
 
     let tls = cfg
         .get("tls")
-        .unwrap_or_else(|| &Value::Boolean(false))
+        .unwrap_or(&Value::Boolean(false))
         .as_bool()
         .unwrap();
     let mut cert = String::new();
@@ -61,13 +61,13 @@ pub fn config() -> Config {
     if tls {
         cert = cfg
             .get("cert")
-            .unwrap_or_else(|| &Value::String(String::new()))
+            .unwrap_or(&Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
         key = cfg
             .get("key")
-            .unwrap_or_else(|| &Value::String(String::new()))
+            .unwrap_or(&Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
@@ -75,7 +75,7 @@ pub fn config() -> Config {
 
     let pass = cfg
         .get("pass")
-        .unwrap_or_else(|| &Value::Boolean(false))
+        .unwrap_or(&Value::Boolean(false))
         .as_bool()
         .unwrap();
 
@@ -84,13 +84,13 @@ pub fn config() -> Config {
     if pass {
         hash = cfg
             .get("hash")
-            .unwrap_or_else(|| &Value::String(String::new()))
+            .unwrap_or(&Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
         secret = cfg
             .get("secret")
-            .unwrap_or_else(|| &Value::String(String::new()))
+            .unwrap_or(&Value::String(String::new()))
             .as_str()
             .unwrap()
             .to_string();
@@ -99,7 +99,7 @@ pub fn config() -> Config {
     #[allow(clippy::cast_sign_loss)]
     let expiry = cfg
         .get("expiry")
-        .unwrap_or_else(|| &Value::Integer(3600))
+        .unwrap_or(&Value::Integer(3600))
         .as_integer()
         .unwrap() as u64;
 
@@ -109,7 +109,7 @@ pub fn config() -> Config {
     #[cfg(feature = "frontend")]
     for i in cfg
         .get("nodes")
-        .unwrap_or_else(|| &Value::Array(Vec::new()))
+        .unwrap_or(&Value::Array(Vec::new()))
         .as_array()
         .unwrap()
     {

--- a/src/backend/src/main.rs
+++ b/src/backend/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
             const DIR: include_dir::Dir = include_dir::include_dir!("dist");
 
             SimpleLogger::new()
-                .with_level(CONFIG.loglevel)
+                .with_level(CONFIG.log_level)
                 .env()
                 .init()
                 .unwrap();

--- a/src/backend/src/main.rs
+++ b/src/backend/src/main.rs
@@ -2,7 +2,6 @@
 use crate::shared::CONFIG;
 use sha2::{Digest, Sha512};
 use simple_logger::SimpleLogger;
-use std::str::FromStr;
 use warp::Filter;
 
 mod config;
@@ -24,7 +23,8 @@ fn main() {
             const DIR: include_dir::Dir = include_dir::include_dir!("dist");
 
             SimpleLogger::new()
-                .with_level(log::LevelFilter::from_str(CONFIG.loglevel.as_str()).unwrap())
+                .with_level(CONFIG.loglevel)
+                .env()
                 .init()
                 .unwrap();
 

--- a/src/backend/src/main.rs
+++ b/src/backend/src/main.rs
@@ -2,6 +2,7 @@
 use crate::shared::CONFIG;
 use sha2::{Digest, Sha512};
 use simple_logger::SimpleLogger;
+use std::str::FromStr;
 use warp::Filter;
 
 mod config;
@@ -23,8 +24,7 @@ fn main() {
             const DIR: include_dir::Dir = include_dir::include_dir!("dist");
 
             SimpleLogger::new()
-                .with_level(log::LevelFilter::Info)
-                .env()
+                .with_level(log::LevelFilter::from_str(CONFIG.loglevel.as_str()).unwrap())
                 .init()
                 .unwrap();
 


### PR DESCRIPTION
If the "RUST_LOG" environment variable is set, it overrides the value from the config file, which makes testing and debugging easier without the need to adjust the config file and hence without affecting the default service.

Also the conversion from String to toml::Value to str back to String, then in `main.rs` from String back to str to log::Level somehow looks like an unnecessary loop. Fascinating that searching around for an hour or so I couldn't find a single example of how a String or str is converted into a log::Level or alternatively log::LevelFilter directly. Probably we can also store the environment valuable || config value || default also directly as log::Level?