### PR TITLE
feat(backend): allow using environment variables to set settings

### DIFF
--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,7 @@ dependencies = [
 name = "dietpi-dashboard"
 version = "0.5.1"
 dependencies = [
+ "figment",
  "futures",
  "if-addrs",
  "include_dir",
@@ -223,7 +233,6 @@ dependencies = [
  "sha2",
  "simple_logger",
  "tokio",
- "toml",
  "walkdir",
  "warp",
  "zip",
@@ -246,6 +255,20 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.0",
  "crypto-common",
+]
+
+[[package]]
+name = "figment"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
 ]
 
 [[package]]
@@ -566,6 +589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20b2b533137b9cad970793453d4f921c2e91312a6d88b1085c07bc15fc51bb3b"
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +786,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "pear"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +865,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1253,6 +1318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
+name = "uncased"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unescape"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1554,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
 
 [[package]]
 name = "zip"

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -61,21 +61,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "biscuit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dee631cea28b00e115fd355a1adedc860b155096941dc01259969eabd434a37"
-dependencies = [
- "chrono",
- "data-encoding",
- "num",
- "once_cell",
- "ring",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,19 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,12 +195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,16 +209,17 @@ dependencies = [
 name = "dietpi-dashboard"
 version = "0.5.1"
 dependencies = [
- "biscuit",
  "futures",
  "if-addrs",
  "include_dir",
  "infer",
+ "jsonwebtoken",
  "lazy_static",
  "log",
  "nanoserde",
  "psutil",
  "pty-process",
+ "serde",
  "sha2",
  "simple_logger",
  "tokio",
@@ -620,6 +587,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012bb02250fdd38faa5feee63235f7a459974440b9b57593822414c31f92839e"
+dependencies = [
+ "base64",
+ "ring",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,82 +732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1075,7 +978,6 @@ version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
- "indexmap",
  "itoa 1.0.1",
  "ryu",
  "serde",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -33,3 +33,15 @@ frontend = ["include_dir", "warp/compression"]
 lto = "fat"
 panic = "abort"
 codegen-units = 1
+
+[profile.release.package.nanoserde]
+opt-level = 3
+
+[profile.release.package.psutil]
+opt-level = 3
+
+[profile.release.package.zip]
+opt-level = 3
+
+[profile.release.package."*"]
+opt-level = "s"

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -22,7 +22,8 @@ toml = "0.5.8"
 if-addrs = "0.7.0"
 zip = { version = "0.5.13", default-features = false, features = ["deflate", "time"] }
 walkdir = "2.3.2"
-biscuit = "0.5.0"
+jsonwebtoken = { version = "8.0.0", default-features = false }
+serde = { version = "1.0.0", features = ["derive"] }
 
 [features]
 default = ["frontend"]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -18,7 +18,7 @@ pty-process = "0.2.0"
 psutil = "3.2.2"
 infer = { version = "0.7.0", default-features = false }
 sha2 = "0.10.2"
-toml = "0.5.8"
+figment = { version = "0.10", features = ["toml", "env"] }
 if-addrs = "0.7.0"
 zip = { version = "0.5.13", default-features = false, features = ["deflate", "time"] }
 walkdir = "2.3.2"

--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -4,21 +4,9 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "log::LevelFilter")]
-pub enum LevelFilterWrap {
-    Off,
-    Error,
-    Warn,
-    Info,
-    Debug,
-    Trace,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize)]
 pub struct Config {
-    #[serde(with = "LevelFilterWrap")]
-    pub log_level: log::LevelFilter,
+    pub log_level: String,
 
     pub port: u16,
 
@@ -38,7 +26,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            log_level: log::LevelFilter::Info,
+            log_level: "info".to_string(),
 
             port: 5252,
 

--- a/src/backend/src/main.rs
+++ b/src/backend/src/main.rs
@@ -2,6 +2,7 @@
 use crate::shared::CONFIG;
 use sha2::{Digest, Sha512};
 use simple_logger::SimpleLogger;
+use std::str::FromStr;
 use warp::Filter;
 
 mod config;
@@ -23,7 +24,9 @@ fn main() {
             const DIR: include_dir::Dir = include_dir::include_dir!("dist");
 
             SimpleLogger::new()
-                .with_level(CONFIG.log_level)
+                .with_level(
+                    log::LevelFilter::from_str(&CONFIG.log_level).expect("Invalid log level"),
+                )
                 .env()
                 .init()
                 .unwrap();

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -1,4 +1,5 @@
 use nanoserde::{DeJson, SerJson};
+use serde::{Deserialize, Serialize};
 
 lazy_static::lazy_static! {
     pub static ref CONFIG: crate::config::Config = crate::config::config();
@@ -147,4 +148,11 @@ pub struct FileSize {
 #[derive(SerJson)]
 pub struct FileUploadFinished {
     pub finished: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct JWTClaims {
+    pub iss: String,
+    pub exp: u64,
+    pub iat: u64,
 }

--- a/src/backend/src/socket_handlers.rs
+++ b/src/backend/src/socket_handlers.rs
@@ -12,7 +12,7 @@ use crate::{page_handlers, shared, systemdata, CONFIG};
 fn validate_token(token: &str) -> bool {
     let mut validator = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
     validator.set_issuer(&["DietPi Dashboard"]);
-    validator.set_required_spec_claims(&["exp", "nbf"]);
+    validator.set_required_spec_claims(&["exp", "iat"]);
     if jsonwebtoken::decode::<shared::JWTClaims>(
         token,
         &jsonwebtoken::DecodingKey::from_secret(CONFIG.secret.as_ref()),

--- a/src/backend/src/socket_handlers.rs
+++ b/src/backend/src/socket_handlers.rs
@@ -10,33 +10,15 @@ use warp::ws::Message;
 use crate::{page_handlers, shared, systemdata, CONFIG};
 
 fn validate_token(token: &str) -> bool {
-    let secret = biscuit::jws::Secret::bytes_from_str(&CONFIG.secret);
-    let encoded: biscuit::jws::Compact<biscuit::ClaimsSet<biscuit::Empty>, biscuit::Empty> =
-        biscuit::JWT::new_encoded(token);
-    let decoded = match encoded.into_decoded(&secret, biscuit::jwa::SignatureAlgorithm::HS256) {
-        Err(_) => return false,
-        Ok(unwrapped) => unwrapped,
-    };
-    let payload = &decoded.payload().unwrap().registered;
-    if payload
-        .validate_claim_presence(biscuit::ClaimPresenceOptions {
-            issued_at: biscuit::Presence::Optional,
-            expiry: biscuit::Presence::Required,
-            not_before: biscuit::Presence::Optional,
-            issuer: biscuit::Presence::Required,
-            audience: biscuit::Presence::Optional,
-            subject: biscuit::Presence::Optional,
-            id: biscuit::Presence::Optional,
-        })
-        .is_err()
-    {
-        return false;
-    }
-    if payload
-        .validate_exp(biscuit::Validation::Validate(
-            biscuit::TemporalOptions::default(),
-        ))
-        .is_err()
+    let mut validator = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
+    validator.set_issuer(&["DietPi Dashboard"]);
+    validator.set_required_spec_claims(&["exp", "nbf"]);
+    if jsonwebtoken::decode::<shared::JWTClaims>(
+        token,
+        &jsonwebtoken::DecodingKey::from_secret(CONFIG.secret.as_ref()),
+        &validator,
+    )
+    .is_err()
     {
         return false;
     }
@@ -68,7 +50,7 @@ pub async fn socket_handler(socket: warp::ws::WebSocket) {
                 continue;
             };
             if CONFIG.pass && !validate_token(&req.token) {
-                quit_send.notify_one();
+                quit_send.notify_waiters();
                 data_send
                     .send(shared::Request {
                         page: "/login".to_string(),
@@ -82,7 +64,7 @@ pub async fn socket_handler(socket: warp::ws::WebSocket) {
             }
             if req.cmd.is_empty() {
                 // Quit out of handler
-                quit_send.notify_one();
+                quit_send.notify_waiters();
             }
             // Send new page/data
             if data_send.send(req.clone()).await.is_err() {


### PR DESCRIPTION
Adds an actual configuration library, uses `serde` without `serde_json`, and uses `jsonwebtoken` instead of `biscuit`. Increases binary size quite a bit, so now optimizes some packages for size instead of speed.