### PR TITLE
refactor(backend): replace lazy_static with once_cell

### DIFF
--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
  "include_dir",
  "infer",
  "jsonwebtoken",
- "lazy_static",
  "log",
  "nanoserde",
+ "once_cell",
  "psutil",
  "pty-process",
  "ring",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "opaque-debug"

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -11,7 +11,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"
 simple_logger = { version = "2.1.0", default-features = false, features = ["colors"] }
 log = "0.4.17"
 include_dir = {version = "0.7.2", optional = true}
-lazy_static = "1.4.0"
 futures = "0.3.21"
 nanoserde = "0.1.30"
 pty-process = "0.2.0"
@@ -25,6 +24,7 @@ walkdir = "2.3.2"
 jsonwebtoken = { version = "8.1.0", default-features = false }
 serde = { version = "1.0.137", features = ["derive"] }
 anyhow = "1.0.57"
+once_cell = "1.12.0"
 
 [features]
 default = ["frontend"]

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -35,7 +35,7 @@ pub struct UsageData {
     pub percent: f32,
 }
 
-#[derive(SerJson, Default, Clone)]
+#[derive(SerJson, Default)]
 pub struct NetData {
     pub sent: u64,
     pub received: u64,

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -35,7 +35,7 @@ pub struct UsageData {
     pub percent: f32,
 }
 
-#[derive(SerJson, Default)]
+#[derive(SerJson, Default, Clone)]
 pub struct NetData {
     pub sent: u64,
     pub received: u64,

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -1,9 +1,8 @@
 use nanoserde::{DeJson, SerJson};
 use serde::{Deserialize, Serialize};
 
-lazy_static::lazy_static! {
-    pub static ref CONFIG: crate::config::Config = crate::config::config();
-}
+pub static CONFIG: once_cell::sync::Lazy<crate::config::Config> =
+    once_cell::sync::Lazy::new(crate::config::config);
 
 // Simple error handling macro, print out error and source (if available), and handle error if it exists
 #[macro_export]

--- a/src/backend/src/systemdata.rs
+++ b/src/backend/src/systemdata.rs
@@ -67,7 +67,10 @@ pub fn network(
         sent: sent.saturating_sub(prev_data.sent),
     };
 
-    *prev_data = data.clone();
+    *prev_data = shared::NetData {
+        received: recv,
+        sent,
+    };
 
     Ok(data)
 }


### PR DESCRIPTION
`once_cell` is eventually going to be included in the standard library (https://github.com/rust-lang/rust/issues/74465), so this will make that transition easier. It also leads to a smaller binary and doesn’t use macros, so allows for proper error handling.