### PR TITLE
perf(backend): various performance improvements

### DIFF
--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -31,9 +31,6 @@ default = ["frontend"]
 frontend = ["include_dir"]
 compression = ["frontend"]
 
-[profile.dev]
-debug = 1
-
 [profile.release]
 lto = "fat"
 panic = "abort"

--- a/src/backend/src/page_handlers.rs
+++ b/src/backend/src/page_handlers.rs
@@ -3,16 +3,14 @@ use futures::stream::SplitSink;
 use futures::SinkExt;
 use nanoserde::SerJson;
 use std::process::Command;
-use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Notify;
-use tokio::sync::{mpsc::Receiver, Mutex};
+use tokio::sync::mpsc::Receiver;
 use tokio::time::sleep;
 use warp::ws::Message;
 
 use crate::{handle_error, shared, systemdata};
 
-type SocketPtr = Arc<Mutex<SplitSink<warp::ws::WebSocket, warp::ws::Message>>>;
+type SocketPtr = SplitSink<warp::ws::WebSocket, warp::ws::Message>;
 
 async fn main_handler_getter() -> anyhow::Result<shared::SysData> {
     Ok(shared::SysData {
@@ -25,12 +23,16 @@ async fn main_handler_getter() -> anyhow::Result<shared::SysData> {
     })
 }
 
-pub async fn main_handler(socket_ptr: SocketPtr, quit: &Arc<Notify>) {
-    let mut socket_send = socket_ptr.lock().await;
+pub async fn main_handler(
+    socket_send: &mut SocketPtr,
+    data_recv: &mut Receiver<Option<shared::Request>>,
+) {
     loop {
         tokio::select! {
             biased;
-            _ = quit.notified() => break,
+            Some(data) = data_recv.recv() => if data.is_none() {
+                break;
+            },
             _ = async {
                 let _send = socket_send
                 .send(Message::text(SerJson::serialize_json(&handle_error!(main_handler_getter().await, shared::SysData::default()))))
@@ -64,15 +66,16 @@ fn process_handler_helper(data: &shared::Request) -> anyhow::Result<()> {
 }
 
 pub async fn process_handler(
-    socket_ptr: SocketPtr,
-    data_recv: &mut Receiver<shared::Request>,
-    quit: &Arc<Notify>,
+    socket_send: &mut SocketPtr,
+    data_recv: &mut Receiver<Option<shared::Request>>,
 ) {
-    let mut socket_send = socket_ptr.lock().await;
     loop {
         tokio::select! {
             biased;
-            _ = quit.notified() => break,
+            Some(data) = data_recv.recv() => match data {
+                Some(data) => handle_error!(process_handler_helper(&data)),
+                None => break,
+            },
             _ = async {
                 let _send = socket_send
                 .send(Message::text(SerJson::serialize_json(
@@ -82,15 +85,14 @@ pub async fn process_handler(
                 )))
                 .await;
                 sleep(Duration::from_secs(1)).await;
-            } => {}
-            Some(data) = data_recv.recv() => handle_error!(process_handler_helper(&data)),
+            } => {},
         }
     }
 }
 
 pub async fn software_handler_helper(
     data: &shared::Request,
-    socket_send: &mut tokio::sync::MutexGuard<'_, SplitSink<warp::ws::WebSocket, Message>>,
+    socket_send: &mut SocketPtr,
 ) -> anyhow::Result<()> {
     // We don't just want to run dietpi-software without args
     anyhow::ensure!(!data.args.is_empty(), "Empty dietpi-software args");
@@ -125,11 +127,9 @@ pub async fn software_handler_helper(
 }
 
 pub async fn software_handler(
-    socket_ptr: SocketPtr,
-    data_recv: &mut Receiver<shared::Request>,
-    quit: &Arc<Notify>,
+    socket_send: &mut SocketPtr,
+    data_recv: &mut Receiver<Option<shared::Request>>,
 ) {
-    let mut socket_send = socket_ptr.lock().await;
     let software = handle_error!(systemdata::dpsoftware(), (Vec::new(), Vec::new()));
     let _send = socket_send
         .send(Message::text(SerJson::serialize_json(
@@ -140,43 +140,34 @@ pub async fn software_handler(
             },
         )))
         .await;
-    loop {
-        tokio::select! {
-            biased;
-            _ = quit.notified() => break,
-            Some(data) = data_recv.recv() => handle_error!(software_handler_helper(&data, &mut socket_send).await),
-        }
+    while let Some(Some(data)) = data_recv.recv().await {
+        handle_error!(software_handler_helper(&data, socket_send).await);
     }
 }
 
 pub async fn management_handler(
-    socket_ptr: SocketPtr,
-    data_recv: &mut Receiver<shared::Request>,
-    quit: &Arc<Notify>,
+    socket_send: &mut SocketPtr,
+    data_recv: &mut Receiver<Option<shared::Request>>,
 ) {
-    let mut socket_send = socket_ptr.lock().await;
     let _send = socket_send
         .send(Message::text(SerJson::serialize_json(&handle_error!(
             systemdata::host(),
             shared::HostData::default()
         ))))
         .await;
-    loop {
-        tokio::select! {
-            biased;
-            _ = quit.notified() => break,
-            // Don't care about the Ok value, so remove it to make the type checker happy
-            Some(data) = data_recv.recv() => handle_error!(Command::new(&data.cmd).spawn().map(|_| ()).with_context(|| format!("Couldn't spawn command {}", &data.cmd))),
-        }
+    while let Some(Some(data)) = data_recv.recv().await {
+        // Don't care about the Ok value, so remove it to make the type checker happy
+        handle_error!(Command::new(&data.cmd)
+            .spawn()
+            .map(|_| ())
+            .with_context(|| format!("Couldn't spawn command {}", &data.cmd)));
     }
 }
 
 pub async fn service_handler(
-    socket_ptr: SocketPtr,
-    data_recv: &mut Receiver<shared::Request>,
-    quit: &Arc<Notify>,
+    socket_send: &mut SocketPtr,
+    data_recv: &mut Receiver<Option<shared::Request>>,
 ) {
-    let mut socket_send = socket_ptr.lock().await;
     let _send = socket_send
         .send(Message::text(SerJson::serialize_json(
             &shared::ServiceList {
@@ -184,25 +175,19 @@ pub async fn service_handler(
             },
         )))
         .await;
-    loop {
-        tokio::select! {
-            biased;
-            _ = quit.notified() => break,
-            Some(data) = data_recv.recv() =>  {
-                handle_error!(Command::new("systemctl")
-                    .args([&data.cmd, data.args[0].as_str()])
-                    .spawn()
-                    .map(|_| ()) // Don't care about the Ok value, so remove it to make the type checker happy
-                    .with_context(|| format!("Couldn't {} service {}", &data.cmd, &data.args[0])));
-                let _send = socket_send
-                    .send(Message::text(SerJson::serialize_json(
-                        &shared::ServiceList {
-                            services: handle_error!(systemdata::services(), Vec::new()),
-                        },
-                    )))
-                    .await;
-            }
-        }
+    while let Some(Some(data)) = data_recv.recv().await {
+        handle_error!(Command::new("systemctl")
+            .args([&data.cmd, data.args[0].as_str()])
+            .spawn()
+            .map(|_| ()) // Don't care about the Ok value, so remove it to make the type checker happy
+            .with_context(|| format!("Couldn't {} service {}", &data.cmd, &data.args[0])));
+        let _send = socket_send
+            .send(Message::text(SerJson::serialize_json(
+                &shared::ServiceList {
+                    services: handle_error!(systemdata::services(), Vec::new()),
+                },
+            )))
+            .await;
     }
 }
 
@@ -273,11 +258,9 @@ async fn browser_handler_helper(
 }
 
 pub async fn browser_handler(
-    socket_ptr: SocketPtr,
-    data_recv: &mut Receiver<shared::Request>,
-    quit: &Arc<Notify>,
+    socket_send: &mut SocketPtr,
+    data_recv: &mut Receiver<Option<shared::Request>>,
 ) {
-    let mut socket_send = socket_ptr.lock().await;
     // Get initial listing of $HOME
     let _send = socket_send
         .send(Message::text(SerJson::serialize_json(
@@ -291,11 +274,8 @@ pub async fn browser_handler(
             },
         )))
         .await;
-    loop {
-        tokio::select! {
-            biased;
-            _ = quit.notified() => break,
-            Some(data) = data_recv.recv() => handle_error!(browser_handler_helper(&data, &mut *socket_send).await),
-        }
+
+    while let Some(Some(data)) = data_recv.recv().await {
+        handle_error!(browser_handler_helper(&data, socket_send).await);
     }
 }

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -42,7 +42,7 @@ pub struct NetData {
     pub received: u64,
 }
 
-#[derive(Debug, Clone, DeJson, Default)]
+#[derive(Debug, Clone, DeJson)]
 pub struct Request {
     #[nserde(default)]
     pub page: String,

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -42,7 +42,7 @@ pub struct NetData {
     pub received: u64,
 }
 
-#[derive(Debug, Clone, DeJson)]
+#[derive(Debug, Clone, DeJson, Default)]
 pub struct Request {
     #[nserde(default)]
     pub page: String,

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -121,7 +121,7 @@ pub struct GlobalData {
     pub temp_unit: TempUnit,
 }
 
-#[derive(SerJson, Debug)]
+#[derive(SerJson)]
 pub struct BrowserData {
     pub path: String,
     pub name: String,

--- a/src/backend/src/systemdata.rs
+++ b/src/backend/src/systemdata.rs
@@ -13,7 +13,6 @@ use tokio::time::sleep;
 
 use crate::shared;
 
-#[allow(clippy::cast_possible_truncation)]
 fn round_percent(unrounded: f32) -> f32 {
     (unrounded * 100.0).round() / 100.0
 }


### PR DESCRIPTION
Some of the more notable ones:
Removed the `Arc<Mutex>` from the main websocket
Removed the `Notify`, back to using an `Option` on the channel to detect if it should quit
Removed many of the `tokio::select!`s, due to not needing to listen for the `Notify`
Terminal handler: 6 `Arc`s, 1 `Notify`, 1 `mpsc` channel, and 1 `RwLock` -> 2 `Arc`s (that's all!)