### PR TITLE
refactor(backend): replace nanoserde with serde_json

### DIFF
--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -18,10 +18,10 @@ jobs:
           rustup target add arm-unknown-linux-musleabihf
           rustup target add armv7-unknown-linux-musleabihf
           rustup target add aarch64-unknown-linux-musl
-      - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v1
-        with:
-          working-directory: src/backend
+      #- name: Restore Rust cache
+      #  uses: Swatinem/rust-cache@v1
+      #  with:
+      #    working-directory: src/backend
       - name: Lint (clippy)
         working-directory: src/backend
         run: |

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Build x86_64
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl --features compression
-      - name: Build armv6l
-        working-directory: src/backend
-        run: cross build --release --target arm-unknown-linux-musleabihf --features compression
+      #- name: Build armv6l
+      #  working-directory: src/backend
+      #  run: cross build --release --target arm-unknown-linux-musleabihf --features compression
       - name: Build armv7l
         working-directory: src/backend
         run: cross build --release --target armv7-unknown-linux-musleabihf --features compression
@@ -58,10 +58,10 @@ jobs:
         with:
           name: dietpi-dashboard-x86_64
           path: src/backend/target/x86_64-unknown-linux-musl/release/dietpi-dashboard
-      - uses: actions/upload-artifact@v2
-        with:
-          name: dietpi-dashboard-armv6l
-          path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
+      #- uses: actions/upload-artifact@v2
+      #  with:
+      #    name: dietpi-dashboard-armv6l
+      #    path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-armv7l
@@ -73,9 +73,9 @@ jobs:
       - name: Build x86_64 (backend only)
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl --no-default-features
-      - name: Build armv6l (backend only)
-        working-directory: src/backend
-        run: cross build --release --target arm-unknown-linux-musleabihf --no-default-features
+      #- name: Build armv6l (backend only)
+      #  working-directory: src/backend
+      #  run: cross build --release --target arm-unknown-linux-musleabihf --no-default-features
       - name: Build armv7l (backend only)
         working-directory: src/backend
         run: cross build --release --target armv7-unknown-linux-musleabihf --no-default-features
@@ -86,10 +86,10 @@ jobs:
         with:
           name: dietpi-dashboard-x86_64-backend
           path: src/backend/target/x86_64-unknown-linux-musl/release/dietpi-dashboard
-      - uses: actions/upload-artifact@v2
-        with:
-          name: dietpi-dashboard-armv6l-backend
-          path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
+      #- uses: actions/upload-artifact@v2
+      #  with:
+      #    name: dietpi-dashboard-armv6l-backend
+      #    path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-armv7l-backend

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -42,12 +42,14 @@ jobs:
         run: yarn build
       - name: Compress frontend files
         run: make compress
+      - run: cargo clean
+        working-directory: src/backend
       - name: Build x86_64
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl --features compression
-      #- name: Build armv6l
-      #  working-directory: src/backend
-      #  run: cross build --release --target arm-unknown-linux-musleabihf --features compression
+      - name: Build armv6l
+        working-directory: src/backend
+        run: cross build --release --target arm-unknown-linux-musleabihf --features compression
       - name: Build armv7l
         working-directory: src/backend
         run: cross build --release --target armv7-unknown-linux-musleabihf --features compression
@@ -58,10 +60,10 @@ jobs:
         with:
           name: dietpi-dashboard-x86_64
           path: src/backend/target/x86_64-unknown-linux-musl/release/dietpi-dashboard
-      #- uses: actions/upload-artifact@v2
-      #  with:
-      #    name: dietpi-dashboard-armv6l
-      #    path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dietpi-dashboard-armv6l
+          path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-armv7l
@@ -73,9 +75,9 @@ jobs:
       - name: Build x86_64 (backend only)
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl --no-default-features
-      #- name: Build armv6l (backend only)
-      #  working-directory: src/backend
-      #  run: cross build --release --target arm-unknown-linux-musleabihf --no-default-features
+      - name: Build armv6l (backend only)
+        working-directory: src/backend
+        run: cross build --release --target arm-unknown-linux-musleabihf --no-default-features
       - name: Build armv7l (backend only)
         working-directory: src/backend
         run: cross build --release --target armv7-unknown-linux-musleabihf --no-default-features
@@ -86,10 +88,10 @@ jobs:
         with:
           name: dietpi-dashboard-x86_64-backend
           path: src/backend/target/x86_64-unknown-linux-musl/release/dietpi-dashboard
-      #- uses: actions/upload-artifact@v2
-      #  with:
-      #    name: dietpi-dashboard-armv6l-backend
-      #    path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dietpi-dashboard-armv6l-backend
+          path: src/backend/target/arm-unknown-linux-musleabihf/release/dietpi-dashboard
       - uses: actions/upload-artifact@v2
         with:
           name: dietpi-dashboard-armv7l-backend

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Build x86_64
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl --features compression
-      #- name: Delete build artifacts
-      #  run: |
-      #    rm -r src/backend/target/release/build/*
-      #    rm src/backend/target/release/deps/*.so
+      - name: Delete build artifacts
+        run: |
+          rm -r src/backend/target/release/build/*
+          rm src/backend/target/release/deps/*.so
       - name: Build armv6l
         working-directory: src/backend
         run: cross build --release --target arm-unknown-linux-musleabihf --features compression

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Build x86_64
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl --features compression
-      - name: Delete build artifacts
-        run: |
-          rm -r src/backend/target/release/build/*
-          rm src/backend/target/release/deps/*.so
+      #- name: Delete build artifacts
+      #  run: |
+      #    rm -r src/backend/target/release/build/*
+      #    rm src/backend/target/release/deps/*.so
       - name: Build armv6l
         working-directory: src/backend
         run: cross build --release --target arm-unknown-linux-musleabihf --features compression

--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -42,8 +42,6 @@ jobs:
         run: yarn build
       - name: Compress frontend files
         run: make compress
-      - run: cargo clean
-        working-directory: src/backend
       - name: Build x86_64
         working-directory: src/backend
         run: cross build --release --target x86_64-unknown-linux-musl --features compression

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -167,12 +167,12 @@ dependencies = [
  "infer",
  "jsonwebtoken",
  "log",
- "nanoserde",
  "once_cell",
  "psutil",
  "pty-process",
  "ring",
  "serde",
+ "serde_json",
  "simple_logger",
  "tokio",
  "walkdir",
@@ -637,21 +637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoserde"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ada81c67664d8256507a2d427273ed307631f0e4bb2bbb56beffd8fe42a1c4d"
-dependencies = [
- "nanoserde-derive",
-]
-
-[[package]]
-name = "nanoserde-derive"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290eec6719d68aef1f5ca0e695f8ad6421adcf8791fc17641c4ccc6c5388fb39"
-
-[[package]]
 name = "nix"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -37,7 +37,7 @@ panic = "abort"
 codegen-units = 1
 strip = true
 
-[profile.release.package.serde_json]
+[profile.release.package.serde]
 opt-level = 3
 
 [profile.release.package.psutil]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -12,7 +12,6 @@ simple_logger = { version = "2.1.0", default-features = false, features = ["colo
 log = "0.4.17"
 include_dir = {version = "0.7.2", optional = true}
 futures = "0.3.21"
-nanoserde = "0.1.30"
 pty-process = "0.2.0"
 psutil = "3.2.2"
 infer = { version = "0.8.1", default-features = false }
@@ -25,6 +24,7 @@ jsonwebtoken = { version = "8.1.1", default-features = false }
 serde = { version = "1.0.137", features = ["derive"] }
 anyhow = "1.0.58"
 once_cell = "1.12.0"
+serde_json = "1.0.81"
 
 [features]
 default = ["frontend"]
@@ -37,7 +37,7 @@ panic = "abort"
 codegen-units = 1
 strip = true
 
-[profile.release.package.nanoserde]
+[profile.release.package.serde_json]
 opt-level = 3
 
 [profile.release.package.psutil]

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -1,4 +1,3 @@
-use nanoserde::{DeJson, SerJson};
 use serde::{Deserialize, Serialize};
 
 pub static CONFIG: once_cell::sync::Lazy<crate::config::Config> =
@@ -18,7 +17,14 @@ macro_rules! handle_error {
     };
 }
 
-#[derive(SerJson, Default)]
+#[macro_export]
+macro_rules! json_msg {
+    ($e: expr, $handler:expr) => {
+        Message::text(handle_error!(serde_json::to_string($e).context("Couldn't serialize json"), $handler))
+    };
+}
+
+#[derive(Serialize, Default)]
 pub struct SysData {
     pub cpu: f32,
     pub ram: UsageData,
@@ -28,32 +34,32 @@ pub struct SysData {
     pub temp: CPUTemp,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct UsageData {
     pub used: u64,
     pub total: u64,
     pub percent: f32,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct NetData {
     pub sent: u64,
     pub received: u64,
 }
 
-#[derive(Debug, Clone, DeJson)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Request {
-    #[nserde(default)]
+    #[serde(default)]
     pub page: String,
-    #[nserde(default)]
+    #[serde(default)]
     pub cmd: String,
-    #[nserde(default)]
+    #[serde(default)]
     pub args: Vec<String>,
-    #[nserde(default)]
+    #[serde(default)]
     pub token: String,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct ProcessData {
     pub pid: u32,
     pub name: String,
@@ -62,12 +68,12 @@ pub struct ProcessData {
     pub status: String,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct ProcessList {
     pub processes: Vec<ProcessData>,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct DPSoftwareData {
     pub id: i16,
     pub name: String,
@@ -76,14 +82,14 @@ pub struct DPSoftwareData {
     pub docs: String,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct DPSoftwareList {
     pub installed: Vec<DPSoftwareData>,
     pub uninstalled: Vec<DPSoftwareData>,
     pub response: String,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct HostData {
     pub hostname: String,
     pub uptime: u64,
@@ -96,7 +102,7 @@ pub struct HostData {
     pub ip: String,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct ServiceData {
     pub name: String,
     pub log: String,
@@ -104,12 +110,12 @@ pub struct ServiceData {
     pub start: String,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct ServiceList {
     pub services: Vec<ServiceData>,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct GlobalData {
     pub update: String,
     pub version: String,
@@ -120,7 +126,7 @@ pub struct GlobalData {
     pub temp_unit: TempUnit,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct BrowserData {
     pub path: String,
     pub name: String,
@@ -130,34 +136,34 @@ pub struct BrowserData {
     pub size: u64,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct BrowserList {
     pub contents: Vec<BrowserData>,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct TokenError {
     pub error: bool,
 }
 
-#[derive(DeJson)]
+#[derive(Deserialize)]
 pub struct FileRequest {
-    #[nserde(default)]
+    #[serde(default)]
     pub cmd: String,
-    #[nserde(default)]
+    #[serde(default)]
     pub path: String,
-    #[nserde(default)]
+    #[serde(default)]
     pub token: String,
-    #[nserde(default)]
+    #[serde(default)]
     pub arg: String,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct FileSize {
     pub size: usize,
 }
 
-#[derive(SerJson)]
+#[derive(Serialize)]
 pub struct FileUploadFinished {
     pub finished: bool,
 }
@@ -169,18 +175,16 @@ pub struct JWTClaims {
     pub iat: u64,
 }
 
-#[derive(SerJson, Default)]
+#[derive(Serialize, Default)]
 pub struct CPUTemp {
     pub available: bool,
     pub celsius: i16,
     pub fahrenheit: i16,
 }
 
-#[derive(Deserialize, Serialize, SerJson, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum TempUnit {
-    #[nserde(rename = "fahrenheit")]
     Fahrenheit,
-    #[nserde(rename = "celsius")]
     Celsius,
 }

--- a/src/backend/src/shared.rs
+++ b/src/backend/src/shared.rs
@@ -65,7 +65,7 @@ pub struct ProcessData {
     pub name: String,
     pub cpu: f32,
     pub ram: u64,
-    pub status: String,
+    pub status: &'static str,
 }
 
 #[derive(Serialize)]
@@ -93,7 +93,7 @@ pub struct DPSoftwareList {
 pub struct HostData {
     pub hostname: String,
     pub uptime: u64,
-    pub arch: String,
+    pub arch: &'static str,
     pub kernel: String,
     pub dp_version: String,
     pub packages: usize,
@@ -106,7 +106,7 @@ pub struct HostData {
 pub struct ServiceData {
     pub name: String,
     pub log: String,
-    pub status: String,
+    pub status: &'static str,
     pub start: String,
 }
 
@@ -130,8 +130,8 @@ pub struct GlobalData {
 pub struct BrowserData {
     pub path: String,
     pub name: String,
-    pub subtype: String,
-    pub maintype: String,
+    pub subtype: &'static str,
+    pub maintype: &'static str,
     pub prettytype: String,
     pub size: u64,
 }


### PR DESCRIPTION
It turns out that with `serde` installed, `serde_json` doesn't actually take up more space. This should lead to more performance, and less allocation, since `serde_json` allows serialization of `&'static str`s.