### PR TITLE
fix(backend): Fix default config value for temp_unit

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,5 +42,5 @@
 
 # Preferred temperature unit
 # - Options: fahrenheit, celsius
-# - Default: celsius
-#temp_unit = celsius
+# - Default: "celsius"
+#temp_unit = "celsius"


### PR DESCRIPTION
Strings need to be double-quoted.