### PR TITLE
refactor(backend): send backend responses as tagged enum

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -33,7 +33,7 @@
     import type { socketData } from "./types";
 
     let socket: WebSocket;
-    let socketData: Partial<socketData> = {};
+    let socketData: socketData;
     let nodes: string[] = [];
     let shown = false;
     let darkMode = false;
@@ -61,6 +61,8 @@
         dpUpdate != "" ||
         cmp(frontendVersion, backendVersion) != 0 ||
         updateAvailable != "";
+
+    $: console.log(socketData);
 
     // Get dark mode
     if (localStorage.getItem("darkMode") != null) {
@@ -105,7 +107,7 @@
 
     const socketMessageListener = (e: MessageEvent) => {
         socketData = JSON.parse(e.data);
-        if (socketData.update != undefined) {
+        if (socketData.dataKind == "GLOBAL") {
             dpUpdate = socketData.update;
             login = socketData.login;
             if (socketData.nodes) {
@@ -136,7 +138,7 @@
                 updateCheck();
             }
         }
-        if (socketData.reauth == true) {
+        if (socketData.dataKind == "REAUTH") {
             loginDialog = true;
         }
         if (navPage) {
@@ -425,32 +427,44 @@
                 ? ' children:blur-2 children:filter'
                 : ''}"
         >
-            {#if shown}
+            {#if shown && socketData != undefined}
                 <Router>
-                    <Route path="process"
-                        ><Process {socketData} {socketSend} /></Route
-                    >
-                    <Route path="/"
-                        ><Home {socketData} {darkMode} {tempUnit} /></Route
-                    >
-                    <Route path="software"
-                        ><Software {socketData} {socketSend} /></Route
-                    >
+                    {#if socketData.dataKind == "PROCESS"}
+                        <Route path="process"
+                            ><Process {socketData} {socketSend} /></Route
+                        >
+                    {/if}
+                    {#if socketData.dataKind == "STATISTIC"}
+                        <Route path="/"
+                            ><Home {socketData} {darkMode} {tempUnit} /></Route
+                        >
+                    {/if}
+                    {#if socketData.dataKind == "SOFTWARE"}
+                        <Route path="software"
+                            ><Software {socketData} {socketSend} /></Route
+                        >
+                    {/if}
                     <Route path="terminal"><Terminal {node} {token} /></Route>
-                    <Route path="management"
-                        ><Management {socketSend} {socketData} /></Route
-                    >
-                    <Route path="browser"
-                        ><FileBrowser
-                            {socketSend}
-                            {socketData}
-                            {node}
-                            {login}
-                        /></Route
-                    >
-                    <Route path="service"
-                        ><Service {socketSend} {socketData} /></Route
-                    >
+                    {#if socketData.dataKind == "MANAGEMENT"}
+                        <Route path="management"
+                            ><Management {socketSend} {socketData} /></Route
+                        >
+                    {/if}
+                    {#if socketData.dataKind == "BROWSER"}
+                        <Route path="browser"
+                            ><FileBrowser
+                                {socketSend}
+                                {socketData}
+                                {node}
+                                {login}
+                            /></Route
+                        >
+                    {/if}
+                    {#if socketData.dataKind == "SERVICE"}
+                        <Route path="service"
+                            ><Service {socketSend} {socketData} /></Route
+                        >
+                    {/if}
                     <Route path=""><h3>Page not found</h3></Route>
                 </Router>
             {:else}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -62,8 +62,6 @@
         cmp(frontendVersion, backendVersion) != 0 ||
         updateAvailable != "";
 
-    $: console.log(socketData);
-
     // Get dark mode
     if (localStorage.getItem("darkMode") != null) {
         darkMode = JSON.parse(localStorage.getItem("darkMode"));

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -212,20 +212,12 @@
     }
 
     function socketSend(cmd: string, args: string[]) {
-        let json;
-        if (login) {
-            json = JSON.stringify({
+        socket.send(
+            JSON.stringify({
                 cmd,
                 args,
-                token,
-            });
-        } else {
-            json = JSON.stringify({
-                cmd,
-                args,
-            });
-        }
-        socket.send(json);
+            })
+        );
     }
 
     function connectSocket(url: string) {

--- a/frontend/src/pages/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser.svelte
@@ -25,9 +25,9 @@
     import Fa from "svelte-fa";
     import prettyBytes from "pretty-bytes";
 
-    import type { socketData, browser } from "../types";
+    import type { browserPage, browserItem } from "../types";
 
-    let selPath: browser = {
+    let selPath: browserItem = {
         name: "",
         path: "",
         maintype: "",
@@ -37,7 +37,7 @@
     };
 
     export let socketSend: (cmd: string, args: string[]) => void;
-    export let socketData: Partial<socketData>;
+    export let socketData: browserPage;
     export let node: string;
     export let login: boolean;
 

--- a/frontend/src/pages/Management.svelte
+++ b/frontend/src/pages/Management.svelte
@@ -3,20 +3,19 @@
     import prettyMilliseconds from "pretty-ms";
     import { fade } from "svelte/transition";
 
-    import type { socketData } from "../types";
+    import type { managementPage } from "../types";
 
     export let socketSend: (cmd: string, args: string[]) => void;
-    export let socketData: Partial<socketData>;
+    export let socketData: managementPage;
 
     let uptime: string;
     let dialog = false;
     let msg = "";
 
-    $: socketData.uptime &&
-        ((uptime = prettyMilliseconds(socketData.uptime * 60000, {
-            verbose: true,
-        })),
-        (dialog = false));
+    $: (uptime = prettyMilliseconds(socketData.uptime * 60000, {
+        verbose: true,
+    })),
+        (dialog = false);
 
     function sendData(data: string) {
         socketSend(data, []);

--- a/frontend/src/pages/Service.svelte
+++ b/frontend/src/pages/Service.svelte
@@ -6,75 +6,71 @@
     } from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
 
-    import type { socketData } from "../types";
+    import type { servicesPage } from "../types";
 
     export let socketSend: (cmd: string, args: string[]) => void;
-    export let socketData: Partial<socketData>;
+    export let socketData: servicesPage;
 </script>
 
 <main>
-    {#if socketData.services}
-        <table
-            class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
-        >
-            <tr class="table-header">
-                <th>Name</th>
-                <th>Status</th>
-                <th>Error Log</th>
-                <th>Start Time</th>
-                <th>Actions</th>
-            </tr>
-            {#each socketData.services as service}
-                <tr
-                    class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
+    <table
+        class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
+    >
+        <tr class="table-header">
+            <th>Name</th>
+            <th>Status</th>
+            <th>Error Log</th>
+            <th>Start Time</th>
+            <th>Actions</th>
+        </tr>
+        {#each socketData.services as service}
+            <tr
+                class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
+            >
+                <td class="p-2">{service.name}</td>
+                <td class="p-2">{service.status}</td>
+                <td class="p-2">
+                    {#if service.log != ""}
+                        <details>
+                            <summary> Show log </summary>
+                            {@html service.log}
+                        </details>
+                    {/if}</td
                 >
-                    <td class="p-2">{service.name}</td>
-                    <td class="p-2">{service.status}</td>
-                    <td class="p-2">
-                        {#if service.log != ""}
-                            <details>
-                                <summary> Show log </summary>
-                                {@html service.log}
-                            </details>
-                        {/if}</td
-                    >
-                    <td class="p-2">{service.start}</td>
-                    <td class="p-2 space-x-2">
-                        {#if service.status == "inactive" || service.status == "failed"}
-                            <span
-                                on:click={() =>
-                                    socketSend("start", [service.name])}
-                                title="Start"
-                                ><Fa
-                                    icon={faPlay}
-                                    class="btn rounded-sm p-0.5"
-                                    size="lg"
-                                /></span
-                            >
-                        {:else}
-                            <span
-                                on:click={() =>
-                                    socketSend("stop", [service.name])}
-                                title="Stop"
-                                ><Fa
-                                    icon={faSquare}
-                                    class="btn p-0.5 rounded-sm p-0.5"
-                                    size="lg"
-                                /></span
-                            ><span
-                                on:click={() =>
-                                    socketSend("restart", [service.name])}
-                                title="Restart"
-                                ><Fa
-                                    icon={faRedoAlt}
-                                    class="btn p-0.5 rounded-sm p-0.5"
-                                    size="lg"
-                                /></span
-                            >
-                        {/if}</td
-                    >
-                </tr>
-            {/each}
-        </table>
-    {/if}
+                <td class="p-2">{service.start}</td>
+                <td class="p-2 space-x-2">
+                    {#if service.status == "inactive" || service.status == "failed"}
+                        <span
+                            on:click={() => socketSend("start", [service.name])}
+                            title="Start"
+                            ><Fa
+                                icon={faPlay}
+                                class="btn rounded-sm p-0.5"
+                                size="lg"
+                            /></span
+                        >
+                    {:else}
+                        <span
+                            on:click={() => socketSend("stop", [service.name])}
+                            title="Stop"
+                            ><Fa
+                                icon={faSquare}
+                                class="btn p-0.5 rounded-sm p-0.5"
+                                size="lg"
+                            /></span
+                        ><span
+                            on:click={() =>
+                                socketSend("restart", [service.name])}
+                            title="Restart"
+                            ><Fa
+                                icon={faRedoAlt}
+                                class="btn p-0.5 rounded-sm p-0.5"
+                                size="lg"
+                            /></span
+                        >
+                    {/if}</td
+                >
+            </tr>
+        {/each}
+    </table>
 </main>

--- a/frontend/src/pages/Software.svelte
+++ b/frontend/src/pages/Software.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import Fa from "svelte-fa";
     import { faCircleNotch } from "@fortawesome/free-solid-svg-icons";
-    import type { socketData } from "../types";
+    import type { softwarePage } from "../types";
 
-    export let socketData: Partial<socketData>;
+    export let socketData: softwarePage;
     export let socketSend: (cmd: string, args: string[]) => void;
 
     let installTemp: boolean[] = [];
@@ -80,69 +80,67 @@
 </script>
 
 <main>
-    {#if socketData.uninstalled}
-        <div class="border-b-2 border-gray-500">
-            <button
-                class="border-1 border-b-0 border-gray-500 p-1 focus:outline-none"
-                on:click={() => (installTable = false)}
-                class:bg-gray-200={!installTable}
-                class:dark:bg-gray-700={!installTable}>Not installed</button
-            >
-            <button
-                class="border-1 border-b-0 border-gray-500 p-1 focus:outline-none"
-                on:click={() => (installTable = true)}
-                class:bg-gray-200={installTable}
-                class:dark:bg-gray-700={installTable}>Installed</button
-            >
-        </div>
-        <table
-            class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
+    <div class="border-b-2 border-gray-500">
+        <button
+            class="border-1 border-b-0 border-gray-500 p-1 focus:outline-none"
+            on:click={() => (installTable = false)}
+            class:bg-gray-200={!installTable}
+            class:dark:bg-gray-700={!installTable}>Not installed</button
         >
-            <tr class="table-header">
-                <th>ID</th>
-                <th>{installTable ? "Uninstall" : "Install"}</th>
-                <th>Name</th>
-                <th>Description</th>
-                <th>Dependencies</th>
-                <th>Documentation link</th>
-            </tr>
-            {#each socketData[installTable ? "installed" : "uninstalled"] as software}
-                {#if software.id != -1}
-                    <tr
-                        class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
+        <button
+            class="border-1 border-b-0 border-gray-500 p-1 focus:outline-none"
+            on:click={() => (installTable = true)}
+            class:bg-gray-200={installTable}
+            class:dark:bg-gray-700={installTable}>Installed</button
+        >
+    </div>
+    <table
+        class="border border-gray-300 dark:border-gray-700 w-full table-fixed break-words"
+    >
+        <tr class="table-header">
+            <th>ID</th>
+            <th>{installTable ? "Uninstall" : "Install"}</th>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Dependencies</th>
+            <th>Documentation link</th>
+        </tr>
+        {#each socketData[installTable ? "installed" : "uninstalled"] as software}
+            {#if software.id != -1}
+                <tr
+                    class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
+                >
+                    <td class="p-2">{software.id}</td>
+                    <td class="p-2"
+                        ><input
+                            type="checkbox"
+                            on:click={() =>
+                                (installTemp[software.id] =
+                                    !installTemp[software.id])}
+                            bind:checked={installTemp[software.id]}
+                            disabled={running}
+                        /></td
                     >
-                        <td class="p-2">{software.id}</td>
-                        <td class="p-2"
-                            ><input
-                                type="checkbox"
-                                on:click={() =>
-                                    (installTemp[software.id] =
-                                        !installTemp[software.id])}
-                                bind:checked={installTemp[software.id]}
-                                disabled={running}
-                            /></td
-                        >
-                        <td class="p-2">{software.name}</td>
-                        <td class="p-2">{software.description}</td>
-                        <td class="p-2">{software.dependencies}</td>
-                        <td class="p-2">
-                            {#if software.docs.substring(0, 5) == "https"}
-                                <a
-                                    href={software.docs}
-                                    class="text-blue-500 underline"
-                                    target="_blank"
-                                >
-                                    {software.docs}
-                                </a>
-                            {:else}
+                    <td class="p-2">{software.name}</td>
+                    <td class="p-2">{software.description}</td>
+                    <td class="p-2">{software.dependencies}</td>
+                    <td class="p-2">
+                        {#if software.docs.substring(0, 5) == "https"}
+                            <a
+                                href={software.docs}
+                                class="text-blue-500 underline"
+                                target="_blank"
+                            >
                                 {software.docs}
-                            {/if}
-                        </td>
-                    </tr>
-                {/if}
-            {/each}
-        </table>
-    {/if}
+                            </a>
+                        {:else}
+                            {software.docs}
+                        {/if}
+                    </td>
+                </tr>
+            {/if}
+        {/each}
+    </table>
     <div class="flex justify-center my-2">
         <button
             on:click={sendSoftware}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,23 +1,48 @@
-interface socketData {
-    // Statistics page
+type socketData =
+    | statisticsPage
+    | softwarePage
+    | processPage
+    | servicesPage
+    | browserPage
+    | managementPage
+    | globalSettings
+    | reauthenticate;
+
+interface statisticsPage {
+    dataKind: "STATISTIC";
     cpu: number;
     ram: usage;
     swap: usage;
     disk: usage;
     network: net;
     temp: temp;
-    // Software page
-    uninstalled: software[];
-    installed: software[];
+}
+
+interface softwarePage {
+    dataKind: "SOFTWARE";
+    uninstalled: softwareItem[];
+    installed: softwareItem[];
     response: string;
-    // Process page
-    processes: processes[];
-    // Services page
-    services: services[];
-    // File browser page
-    contents: browser[];
+}
+
+interface processPage {
+    dataKind: "PROCESS";
+    processes: processItem[];
+}
+
+interface servicesPage {
+    dataKind: "SERVICE";
+    services: serviceItem[];
+}
+
+interface browserPage {
+    dataKind: "BROWSER";
+    contents: browserItem[];
     textdata: string;
-    // Management page
+}
+
+interface managementPage {
+    dataKind: "MANAGEMENT";
     hostname: string;
     uptime: number;
     arch: string;
@@ -27,17 +52,24 @@ interface socketData {
     upgrades: number;
     nic: string;
     ip: string;
-    // Global
+}
+
+interface globalSettings {
+    dataKind: "GLOBAL";
     update: string;
     login: boolean;
-    reauth: boolean;
     nodes: string[];
     version: string;
     update_check: boolean;
     temp_unit: "fahrenheit" | "celsius";
 }
 
-interface software {
+interface reauthenticate {
+    dataKind: "REAUTH";
+    reauth: true;
+}
+
+interface softwareItem {
     id: number;
     name: string;
     description: string;
@@ -45,7 +77,7 @@ interface software {
     docs: string;
 }
 
-interface processes {
+interface processItem {
     pid: number;
     name: string;
     cpu: number;
@@ -53,14 +85,14 @@ interface processes {
     status: string;
 }
 
-interface services {
+interface serviceItem {
     name: string;
     status: string;
     log: string;
     start: string;
 }
 
-interface browser {
+interface browserItem {
     name: string;
     path: string;
     prettytype: string;
@@ -86,5 +118,15 @@ interface temp {
     fahrenheit: number;
 }
 
-// 'browser' required for selected path in file browser
-export type { socketData, browser };
+// 'browserItem' required for selected path in file browser
+export type {
+    socketData,
+    statisticsPage,
+    softwarePage,
+    processPage,
+    servicesPage,
+    browserPage,
+    managementPage,
+    globalSettings,
+    browserItem,
+};

--- a/src/page_handlers.rs
+++ b/src/page_handlers.rs
@@ -1,15 +1,12 @@
 use anyhow::Context;
-use futures::stream::SplitSink;
-use futures::SinkExt;
 use std::time::Duration;
 use tokio::process::Command;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::sleep;
-use tokio_tungstenite::tungstenite::Message;
 use tracing::instrument;
 
 use crate::{
-    handle_error, json_msg,
+    handle_error,
     shared::{self, RequestTypes, SocketSend},
     systemdata,
 };

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -92,45 +92,19 @@ pub struct NetData {
     pub received: u64,
 }
 
-#[derive(Deserialize)]
-pub struct Request {
-    #[serde(default)]
-    page: Option<String>,
-    #[serde(default)]
-    cmd: Option<String>,
-    #[serde(default)]
-    args: Option<Vec<String>>,
-    #[serde(default)]
-    token: Option<String>,
-}
-
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
 pub enum RequestTypes {
-    Page(String),
+    Page {
+        page: String,
+    },
     Cmd {
         cmd: String,
         args: Option<Vec<String>>,
     },
-    Token(String),
-}
-
-impl TryFrom<Request> for RequestTypes {
-    type Error = anyhow::Error;
-
-    fn try_from(value: Request) -> Result<Self, Self::Error> {
-        if let Some(page) = value.page {
-            Ok(Self::Page(page))
-        } else if let Some(cmd) = value.cmd {
-            Ok(Self::Cmd {
-                cmd,
-                args: value.args,
-            })
-        } else if let Some(token) = value.token {
-            Ok(Self::Token(token))
-        } else {
-            Err(anyhow::anyhow!("All fields are None"))
-        }
-    }
+    Token {
+        token: String,
+    },
 }
 
 #[derive(Serialize)]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -19,13 +19,6 @@ macro_rules! handle_error {
     };
 }
 
-#[macro_export]
-macro_rules! json_msg {
-    ($e: expr, $handler:expr) => {
-        Message::text(handle_error!(serde_json::to_string($e).context("Couldn't serialize json"), $handler))
-    };
-}
-
 pub fn remove_color_codes(s: &str) -> String {
     s.replace('\u{1b}', "")
         .replace("[33m", "")

--- a/src/socket_handlers.rs
+++ b/src/socket_handlers.rs
@@ -465,7 +465,7 @@ pub async fn file_handler(
                         }
                         Some(FileHandlerHelperReturns::SizeBuf(size, buf)) => {
                             if socket_send
-                                .send(crate::json_msg!(&size, continue))
+                                .send(Message::text(handle_error!(serde_json::to_string(&size).context("Couldn't serialize json"), continue)))
                                 .await
                                 .is_err()
                             {

--- a/src/systemdata.rs
+++ b/src/systemdata.rs
@@ -202,7 +202,7 @@ pub async fn host() -> anyhow::Result<shared::HostData> {
     let dp_file = fs::read_to_string("/boot/dietpi/.version")
         .await
         .context("Couldn't get DietPi version")?;
-    let dp_version: Vec<&str> = dp_file.split(&['=', '\n'][..]).collect();
+    let dp_version: Vec<&str> = dp_file.split(['=', '\n']).collect();
     // Much faster than 'apt list --installed'
     // Count number of newlines
     let installed_pkgs = Command::new("dpkg")
@@ -227,14 +227,7 @@ pub async fn host() -> anyhow::Result<shared::HostData> {
         arch = "armv7l";
     }
     let addrs = &if_addrs::get_if_addrs().context("Couldn't get IP addresses")?;
-    // Start with first address (probably loopback), and loop to try to get an actual one
-    let mut addr = &addrs[0];
-    for i in addrs {
-        if !i.is_loopback() {
-            addr = i;
-            break;
-        }
-    }
+    let addr = addrs.iter().find(|x| !x.is_loopback()).unwrap_or(&addrs[0]);
     Ok(shared::HostData {
         hostname: info.hostname().to_string(),
         uptime,


### PR DESCRIPTION
*Part 1 of 3 to clean up frontend*

Sends the responses from the backend with a `dataKind` field, makes it so each page in the frontend only uses the types from the websocket that it needs.