### PR TITLE
refactor(backend): use mime_guess instead of infer for file type guessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,8 +168,8 @@ dependencies = [
  "hyper",
  "if-addrs",
  "include_dir",
- "infer",
  "jsonwebtoken",
+ "mime_guess",
  "once_cell",
  "psutil",
  "pty-process",
@@ -466,12 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f551f8c3a39f68f986517db0d1759de85881894fdc7db798bd2a9df9cb04b7fc"
-
-[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +547,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -1163,6 +1173,15 @@ name = "unescape"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ include_dir = { version = "0.7.3", optional = true }
 futures = "0.3.27"
 pty-process = "0.2.0"
 psutil = "3.2.2"
-infer = { version = "0.13.0", default-features = false }
 ring = "0.16.20"
 figment = { version = "0.10", features = ["toml", "env"] }
 if-addrs = "0.10.1"
@@ -37,6 +36,7 @@ tokio-rustls = "0.23.4"
 rustls-pemfile = "1.0.2"
 getrandom = "0.2.8"
 hex = "0.4.3"
+mime_guess = { version = "2.0.4", default-features = false }
 
 [features]
 default = ["frontend"]

--- a/frontend/src/pages/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser.svelte
@@ -354,7 +354,7 @@
                                         currentPath = contents.path;
                                         break;
                                     case "text":
-                                        if (contents.subtype == "large") {
+                                        if (contents.size > 2 * 1000 * 1000) {
                                             if (
                                                 confirm(
                                                     "Can't view files above 2MB, would you like to download instead?"

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -204,8 +204,8 @@ pub struct GlobalData {
 pub struct BrowserData {
     pub path: String,
     pub name: String,
-    pub subtype: &'static str,
-    pub maintype: &'static str,
+    pub subtype: String,
+    pub maintype: String,
     pub prettytype: String,
     pub size: u64,
 }

--- a/src/systemdata.rs
+++ b/src/systemdata.rs
@@ -378,19 +378,20 @@ pub async fn browser_dir(path: &std::path::Path) -> anyhow::Result<Vec<shared::B
                 maintype = "unknown".to_string();
                 subtype = "unknown".to_string();
                 prettytype = "Binary file".to_string();
-            } else if mime_type == mime_guess::mime::TEXT_STAR
+            } else if mime_type.type_() == mime_guess::mime::TEXT
                 || mime_type == mime_guess::mime::APPLICATION_JAVASCRIPT // Javascript and JSON are also text files, for our purposes
                 || mime_type == mime_guess::mime::APPLICATION_JSON
             {
+                println!("Text file");
                 maintype = "text".to_string();
-                subtype = mime_type.subtype().as_str().to_string();
+                subtype = mime_type.subtype().as_str().replace("x-", "");
 
                 let subtype_upper = uppercase_first_letter(&subtype);
 
                 prettytype = format!("{}{} File", subtype_upper.0, subtype_upper.1);
             } else {
                 maintype = mime_type.type_().as_str().to_string();
-                subtype = mime_type.subtype().as_str().to_string();
+                subtype = mime_type.subtype().as_str().replace("x-", "");
 
                 let maintype_upper = uppercase_first_letter(&maintype);
                 let subtype_upper = subtype.to_ascii_uppercase();

--- a/src/systemdata.rs
+++ b/src/systemdata.rs
@@ -322,12 +322,19 @@ pub async fn global() -> shared::GlobalData {
     }
 }
 
+fn uppercase_first_letter(word: &str) -> (char, &str) {
+    let first_letter = word.chars().next().unwrap().to_ascii_uppercase();
+    (first_letter, &word[1..])
+}
+
 #[instrument]
 pub async fn browser_dir(path: &std::path::Path) -> anyhow::Result<Vec<shared::BrowserData>> {
     let mut dir = fs::read_dir(path)
         .await
         .with_context(|| format!("Couldn't read path {}", path.display()))?;
+
     let mut file_list = Vec::new();
+
     while let Ok(Some(file)) = dir.next_entry().await {
         tracing::debug!(
             "Got {} with type {:?}",
@@ -347,6 +354,7 @@ pub async fn browser_dir(path: &std::path::Path) -> anyhow::Result<Vec<shared::B
                 })
                 .unwrap_or("unknown")
         );
+
         // Resolve all symlinks
         let path = fs::canonicalize(file.path())
             .await
@@ -354,63 +362,50 @@ pub async fn browser_dir(path: &std::path::Path) -> anyhow::Result<Vec<shared::B
         let metadata = fs::metadata(&path)
             .await
             .with_context(|| format!("Couldn't get metadata for path {}", &path.display()))?;
+
         let maintype;
         let subtype;
         let prettytype;
+
         if metadata.is_dir() {
-            maintype = "dir";
-            subtype = "";
+            maintype = "dir".to_string();
+            subtype = String::new();
             prettytype = "Directory".to_string();
         } else if metadata.is_file() {
-            let buf = fs::read(&path)
-                .await
-                .with_context(|| format!("Couldn't read directory {}", &path.display()))?;
-            if let Some(infertype) = infer::get(&buf) {
-                subtype = infertype
-                    .mime_type()
-                    .split_once('/')
-                    .with_context(|| format!("Couldn't split mime type {}", infertype.mime_type()))?
-                    .1;
-                maintype = {
-                    if infer::is_app(&buf) {
-                        "application"
-                    } else if infer::is_archive(&buf) {
-                        "archive"
-                    } else if infer::is_audio(&buf) {
-                        "audio"
-                    } else if infer::is_image(&buf) {
-                        "image"
-                    } else if infer::is_video(&buf) {
-                        "video"
-                    } else {
-                        "unknown"
-                    }
-                };
+            let mime_type = mime_guess::from_path(&path).first_or_octet_stream();
+
+            if mime_type == mime_guess::mime::APPLICATION_OCTET_STREAM {
+                maintype = "unknown".to_string();
+                subtype = "unknown".to_string();
+                prettytype = "Binary file".to_string();
+            } else if mime_type == mime_guess::mime::TEXT_STAR
+                || mime_type == mime_guess::mime::APPLICATION_JAVASCRIPT // Javascript and JSON are also text files, for our purposes
+                || mime_type == mime_guess::mime::APPLICATION_JSON
+            {
+                maintype = "text".to_string();
+                subtype = mime_type.subtype().as_str().to_string();
+
+                let subtype_upper = uppercase_first_letter(&subtype);
+
+                prettytype = format!("{}{} File", subtype_upper.0, subtype_upper.1);
+            } else {
+                maintype = mime_type.type_().as_str().to_string();
+                subtype = mime_type.subtype().as_str().to_string();
+
+                let maintype_upper = uppercase_first_letter(&maintype);
+                let subtype_upper = subtype.to_ascii_uppercase();
+
                 prettytype = format!(
                     "{} {}{} File",
-                    subtype.to_uppercase(),
-                    // Get first character, could (theoretically) panic
-                    &maintype[0..1].to_uppercase(),
-                    &maintype[1..]
+                    subtype_upper, maintype_upper.0, maintype_upper.1
                 );
-            } else if from_utf8(&buf).is_err() {
-                maintype = "unknown";
-                subtype = "unknown";
-                prettytype = "Binary file".to_string();
-            } else {
-                if metadata.len() > 2 * 1000 * 1000 {
-                    subtype = "large";
-                } else {
-                    subtype = "plain";
-                }
-                maintype = "text";
-                prettytype = "Plain Text File".to_string();
             }
         } else {
-            maintype = "notafile";
-            subtype = "notafile";
+            maintype = "notafile".to_string();
+            subtype = "notafile".to_string();
             prettytype = "Special File".to_string();
         }
+
         file_list.push(shared::BrowserData {
             path: crate::handle_error!(
                 file.path()

--- a/src/systemdata.rs
+++ b/src/systemdata.rs
@@ -323,6 +323,8 @@ pub async fn global() -> shared::GlobalData {
 }
 
 fn uppercase_first_letter(word: &str) -> (char, &str) {
+    // There will always be at least one letter in the mime type
+    #[allow(clippy::unwrap_used)]
     let first_letter = word.chars().next().unwrap().to_ascii_uppercase();
     (first_letter, &word[1..])
 }

--- a/src/systemdata.rs
+++ b/src/systemdata.rs
@@ -382,7 +382,6 @@ pub async fn browser_dir(path: &std::path::Path) -> anyhow::Result<Vec<shared::B
                 || mime_type == mime_guess::mime::APPLICATION_JAVASCRIPT // Javascript and JSON are also text files, for our purposes
                 || mime_type == mime_guess::mime::APPLICATION_JSON
             {
-                println!("Text file");
                 maintype = "text".to_string();
                 subtype = mime_type.subtype().as_str().replace("x-", "");
 


### PR DESCRIPTION
This avoids unnecessary file reads when trying to get the contents of a directory. These reads could cause OOM errors, or just make the directory listing unnecessarily slow.

Resolves #513 (again)