### PR TITLE
refactor(frontend): minor correctness changes

### DIFF
--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": true,
+    "arrowParens": "avoid",
+    "printWidth": 90,
+    "plugins": ["prettier-plugin-svelte"]
+  }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "@types/microlight": "^0.0.0",
     "@types/semver-compare-multi": "^1.0.0",
     "postcss": "^8.4.21",
+    "prettier": "^2.8.4",
+    "prettier-plugin-svelte": "^2.9.0",
     "svelte": "^3.55.1",
     "svelte-check": "^3.0.3",
     "svelte-fa": "^3.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,6 +9,8 @@ specifiers:
   '@types/semver-compare-multi': ^1.0.0
   microlight: ^0.0.7
   postcss: ^8.4.21
+  prettier: ^2.8.4
+  prettier-plugin-svelte: ^2.9.0
   pretty-bytes: ^6.0.0
   pretty-ms: ^8.0.0
   semver-compare-multi: ^1.0.3
@@ -47,6 +49,8 @@ devDependencies:
   '@types/microlight': 0.0.0
   '@types/semver-compare-multi': 1.0.0
   postcss: 8.4.21
+  prettier: 2.8.4
+  prettier-plugin-svelte: 2.9.0_jrsxveqmsx2uadbqiuq74wlc4u
   svelte: 3.55.1
   svelte-check: 3.0.3_pehl75e5jsy22vp33udjja4soi
   svelte-fa: 3.0.3
@@ -829,8 +833,24 @@ packages:
       svelte: 3.55.1
     dev: true
 
+  /prettier-plugin-svelte/2.9.0_jrsxveqmsx2uadbqiuq74wlc4u:
+    resolution: {integrity: sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==}
+    peerDependencies:
+      prettier: ^1.16.4 || ^2.0.0
+      svelte: ^3.2.0
+    dependencies:
+      prettier: 2.8.4
+      svelte: 3.55.1
+    dev: true
+
   /prettier/2.8.1:
     resolution: {integrity: sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
+  /prettier/2.8.4:
+    resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -61,13 +61,13 @@
 
     $: node && (((shown = false), (reopenSocket = false)), connectSocket(node));
     $: notify =
-        dpUpdate != "" ||
-        cmp(frontendVersion, backendVersion) != 0 ||
-        updateAvailable != "";
+        dpUpdate !== "" ||
+        cmp(frontendVersion, backendVersion) !== 0 ||
+        updateAvailable !== "";
 
     // Get dark mode
     let darkModeTemp = localStorage.getItem("darkMode");
-    if (darkModeTemp != null) {
+    if (darkModeTemp !== null) {
         darkMode = JSON.parse(darkModeTemp);
     } else {
         darkMode = window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -76,7 +76,7 @@
     const updateCheck = () => {
         let updateCheckTemp = localStorage.getItem("update-check");
         if (
-            updateCheckTemp == null ||
+            updateCheckTemp === null ||
             JSON.parse(updateCheckTemp).lastChecked + 86400 <
                 Math.round(Date.now() / 1000)
         ) {
@@ -97,7 +97,7 @@
                     );
                 })
             );
-        } else if (updateCheckTemp != null) {
+        } else if (updateCheckTemp !== null) {
             let version = JSON.parse(updateCheckTemp).version;
             if (cmp(version, backendVersion) > 0) {
                 updateAvailable = version;
@@ -107,7 +107,7 @@
 
     const socketMessageListener = (e: MessageEvent) => {
         socketData = JSON.parse(e.data);
-        if (socketData.dataKind == "GLOBAL") {
+        if (socketData.dataKind === "GLOBAL") {
             dpUpdate = socketData.update;
             login = socketData.login;
             if (socketData.nodes) {
@@ -117,7 +117,7 @@
             tempUnit = socketData.temp_unit;
             // Get token
             if (login) {
-                if (tokens[node] == null) {
+                if (tokens[node] === null) {
                     // Login
                     loginDialog = true;
                 } else {
@@ -137,7 +137,7 @@
                 updateCheck();
             }
         }
-        if (socketData.dataKind == "REAUTH") {
+        if (socketData.dataKind === "REAUTH") {
             loginDialog = true;
         }
         if (navPage) {
@@ -164,7 +164,7 @@
     };
 
     function pollServer(page: string) {
-        if (page != "/terminal") {
+        if (page !== "/terminal") {
             // Terminal doesn't work if sent
             socket.send(
                 JSON.stringify({
@@ -175,7 +175,7 @@
     }
 
     function changePage(page: string) {
-        if (page != window.location.pathname) {
+        if (page !== window.location.pathname) {
             blur = true;
             pollServer(page);
             navPage = page;
@@ -190,7 +190,7 @@
         };
         fetch(`${window.location.protocol}//${node}/login/`, options).then(response => {
             password = "";
-            if (response.status == 401) {
+            if (response.status === 401) {
                 passwordMessage = true;
                 setTimeout(() => (passwordMessage = false), 2000);
                 return;
@@ -221,7 +221,7 @@
         } else {
             reopenSocket = true;
         }
-        let proto = window.location.protocol == "https:" ? "wss" : "ws";
+        let proto = window.location.protocol === "https:" ? "wss" : "ws";
         socket = new WebSocket(`${proto}://${url}/ws`);
         socket.onopen = socketOpenListener;
         socket.onmessage = socketMessageListener;
@@ -307,7 +307,7 @@
                 ><img src={logo} alt="DietPi logo" class="h-10" /></a
             >
             <div class="flex justify-around">
-                {#if nodes.length != 0}
+                {#if nodes.length !== 0}
                     <select bind:value={node} class="hidden md:inline-block">
                         <option
                             value={`${window.location.hostname}:${window.location.port}`}
@@ -341,7 +341,7 @@
                         {/if}
                     </span>
                 </div>
-                {#if nodes.length != 0}
+                {#if nodes.length !== 0}
                     <span
                         class="cursor-pointer md:hidden"
                         on:click={() => (settingsShown = !settingsShown)}
@@ -366,7 +366,7 @@
                                 >DietPi update available: {dpUpdate}</tr
                             >
                         {/if}
-                        {#if cmp(frontendVersion, backendVersion) != 0}
+                        {#if cmp(frontendVersion, backendVersion) !== 0}
                             <tr class="border-b border-gray-300 border-gray-600"
                                 >Warning: Current node is running a version of
                                 DietPi-Dashboard {cmp(frontendVersion, backendVersion) < 0
@@ -408,28 +408,28 @@
                 ? ' children:blur-2 children:filter'
                 : ''}"
         >
-            {#if shown && socketData != undefined}
+            {#if shown && socketData !== undefined}
                 <Router>
-                    {#if socketData.dataKind == "PROCESS"}
+                    {#if socketData.dataKind === "PROCESS"}
                         <Route path="process"><Process {socketData} {socketSend} /></Route
                         >
                     {/if}
-                    {#if socketData.dataKind == "STATISTIC"}
+                    {#if socketData.dataKind === "STATISTIC"}
                         <Route path="/"><Home {socketData} {darkMode} {tempUnit} /></Route
                         >
                     {/if}
-                    {#if socketData.dataKind == "SOFTWARE"}
+                    {#if socketData.dataKind === "SOFTWARE"}
                         <Route path="software"
                             ><Software {socketData} {socketSend} /></Route
                         >
                     {/if}
                     <Route path="terminal"><Terminal {node} {token} /></Route>
-                    {#if socketData.dataKind == "MANAGEMENT"}
+                    {#if socketData.dataKind === "MANAGEMENT"}
                         <Route path="management"
                             ><Management {socketSend} {socketData} /></Route
                         >
                     {/if}
-                    {#if socketData.dataKind == "BROWSER"}
+                    {#if socketData.dataKind === "BROWSER"}
                         <Route path="browser"
                             ><FileBrowser
                                 {socketSend}
@@ -440,7 +440,7 @@
                             /></Route
                         >
                     {/if}
-                    {#if socketData.dataKind == "SERVICE"}
+                    {#if socketData.dataKind === "SERVICE"}
                         <Route path="service"><Service {socketSend} {socketData} /></Route
                         >
                     {/if}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -72,14 +72,13 @@
     const updateCheck = () => {
         if (
             localStorage.getItem("update-check") == null ||
-            JSON.parse(localStorage.getItem("update-check")).lastChecked +
-                86400 <
+            JSON.parse(localStorage.getItem("update-check")).lastChecked + 86400 <
                 Math.round(Date.now() / 1000)
         ) {
             fetch(
                 "https://api.github.com/repos/ravenclaw900/DietPi-Dashboard/releases/latest"
-            ).then((response) =>
-                response.text().then((body) => {
+            ).then(response =>
+                response.text().then(body => {
                     let version = JSON.parse(body).name.substring(1);
                     if (cmp(version, backendVersion) > 0) {
                         updateAvailable = version;
@@ -94,9 +93,7 @@
                 })
             );
         } else if (localStorage.getItem("update-check") != null) {
-            let version = JSON.parse(
-                localStorage.getItem("update-check")
-            ).version;
+            let version = JSON.parse(localStorage.getItem("update-check")).version;
             if (cmp(version, backendVersion) > 0) {
                 updateAvailable = version;
             }
@@ -187,28 +184,26 @@
             method: "POST",
             body: password,
         };
-        fetch(`${window.location.protocol}//${node}/login/`, options).then(
-            (response) => {
-                password = "";
-                if (response.status == 401) {
-                    passwordMessage = true;
-                    setTimeout(() => (passwordMessage = false), 2000);
-                    return;
-                }
-                response.text().then((body) => {
-                    token = body;
-                    let obj =
-                        localStorage.getItem("tokens") == null
-                            ? {}
-                            : JSON.parse(localStorage.getItem("tokens"));
-                    obj[node] = body;
-                    localStorage.setItem("tokens", JSON.stringify(obj));
-                    loginDialog = false;
-                    socket.send(JSON.stringify({ token }));
-                    pollServer(window.location.pathname);
-                });
+        fetch(`${window.location.protocol}//${node}/login/`, options).then(response => {
+            password = "";
+            if (response.status == 401) {
+                passwordMessage = true;
+                setTimeout(() => (passwordMessage = false), 2000);
+                return;
             }
-        );
+            response.text().then(body => {
+                token = body;
+                let obj =
+                    localStorage.getItem("tokens") == null
+                        ? {}
+                        : JSON.parse(localStorage.getItem("tokens"));
+                obj[node] = body;
+                localStorage.setItem("tokens", JSON.stringify(obj));
+                loginDialog = false;
+                socket.send(JSON.stringify({ token }));
+                pollServer(window.location.pathname);
+            });
+        });
     }
 
     function socketSend(cmd: string, args: string[]) {
@@ -265,9 +260,7 @@
                     >
                 </form>
                 {#if passwordMessage}
-                    <h6 class="text-red-500" transition:fade>
-                        Incorrect password
-                    </h6>
+                    <h6 class="text-red-500" transition:fade>Incorrect password</h6>
                 {/if}
             </div>
         </div>
@@ -310,10 +303,7 @@
             <span on:click={() => (menu = !menu)} class="justify-self-start"
                 ><Fa icon={faBars} class="p-1 ml-1 btn" size="3x" /></span
             >
-            <a
-                href="https://dietpi.com"
-                class="justify-self-center"
-                target="_blank"
+            <a href="https://dietpi.com" class="justify-self-center" target="_blank"
                 ><img src={logo} alt="DietPi logo" class="h-10" /></a
             >
             <div class="flex justify-around">
@@ -333,8 +323,7 @@
                 <div>
                     <span
                         class="cursor-pointer"
-                        on:click={() =>
-                            (notificationsShown = !notificationsShown)}
+                        on:click={() => (notificationsShown = !notificationsShown)}
                         >{#if notify}
                             <FaLayers size="lg">
                                 <Fa icon={faEnvelope} />
@@ -369,10 +358,7 @@
             </div>
         </header>
         {#if notificationsShown}
-            <div
-                class="p-2 bg-gray-50 dark:bg-gray-800 dark:text-white"
-                transition:slide
-            >
+            <div class="p-2 bg-gray-50 dark:bg-gray-800 dark:text-white" transition:slide>
                 <div class="min-h-10">
                     <table class="w-full">
                         {#if dpUpdate}
@@ -383,10 +369,7 @@
                         {#if cmp(frontendVersion, backendVersion) != 0}
                             <tr class="border-b border-gray-300 border-gray-600"
                                 >Warning: Current node is running a version of
-                                DietPi-Dashboard {cmp(
-                                    frontendVersion,
-                                    backendVersion
-                                ) < 0
+                                DietPi-Dashboard {cmp(frontendVersion, backendVersion) < 0
                                     ? "greater"
                                     : "lower"} than the main node (main: {frontendVersion},
                                 node: {backendVersion})</tr
@@ -428,13 +411,11 @@
             {#if shown && socketData != undefined}
                 <Router>
                     {#if socketData.dataKind == "PROCESS"}
-                        <Route path="process"
-                            ><Process {socketData} {socketSend} /></Route
+                        <Route path="process"><Process {socketData} {socketSend} /></Route
                         >
                     {/if}
                     {#if socketData.dataKind == "STATISTIC"}
-                        <Route path="/"
-                            ><Home {socketData} {darkMode} {tempUnit} /></Route
+                        <Route path="/"><Home {socketData} {darkMode} {tempUnit} /></Route
                         >
                     {/if}
                     {#if socketData.dataKind == "SOFTWARE"}
@@ -459,8 +440,7 @@
                         >
                     {/if}
                     {#if socketData.dataKind == "SERVICE"}
-                        <Route path="service"
-                            ><Service {socketSend} {socketData} /></Route
+                        <Route path="service"><Service {socketSend} {socketData} /></Route
                         >
                     {/if}
                     <Route path=""><h3>Page not found</h3></Route>
@@ -485,9 +465,7 @@
                     target="_blank">More Info</a
                 >
             </div>
-            <a
-                href="https://github.com/ravenclaw900/DietPi-Dashboard"
-                target="_blank"
+            <a href="https://github.com/ravenclaw900/DietPi-Dashboard" target="_blank"
                 ><img
                     src={github}
                     width="30px"

--- a/frontend/src/pages/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser.svelte
@@ -41,6 +41,7 @@
     export let socketData: browserPage;
     export let node: string;
     export let login: boolean;
+    export let token: string;
 
     let fileDialog: HTMLInputElement;
     let fileText: HTMLTextAreaElement;
@@ -61,7 +62,7 @@
 
     const fileSocket = new WebSocket(
         `${window.location.protocol == "https:" ? "wss" : "ws"}://${node}/ws/file${
-            login ? `?token=${JSON.parse(localStorage.getItem("tokens"))[node]}` : ""
+            login ? `?token=${token}` : ""
         }`
     );
     fileSocket.onmessage = (e: MessageEvent) => {
@@ -191,7 +192,7 @@
         }
     }
 
-    function validateInput(name: string) {
+    function validateInput(name: string | null) {
         if (name) {
             for (let element of socketData.contents) {
                 if (element.name == name) {
@@ -462,22 +463,24 @@
                             class="hidden"
                             bind:this={fileDialog}
                             on:input={() => {
-                                let size = Math.ceil(
-                                    fileDialog.files[0].size / (1000 * 1000)
-                                );
-                                fileSend(
-                                    `${currentPath}/${fileDialog.files[0].name}`,
-                                    "up",
-                                    `${size}`
-                                );
-                                for (
-                                    let i = 0;
-                                    i < fileDialog.files[0].size;
-                                    i += 1000 * 1000
-                                ) {
-                                    fileSocket.send(
-                                        fileDialog.files[0].slice(i, i + 1000 * 1000)
+                                if (fileDialog.files != null) {
+                                    let size = Math.ceil(
+                                        fileDialog.files[0].size / (1000 * 1000)
                                     );
+                                    fileSend(
+                                        `${currentPath}/${fileDialog.files[0].name}`,
+                                        "up",
+                                        `${size}`
+                                    );
+                                    for (
+                                        let i = 0;
+                                        i < fileDialog.files[0].size;
+                                        i += 1000 * 1000
+                                    ) {
+                                        fileSocket.send(
+                                            fileDialog.files[0].slice(i, i + 1000 * 1000)
+                                        );
+                                    }
                                 }
                             }}
                         /><Fa icon={faFileUpload} size="lg" /></span

--- a/frontend/src/pages/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser.svelte
@@ -61,12 +61,12 @@
     let binURL = "";
 
     const fileSocket = new WebSocket(
-        `${window.location.protocol == "https:" ? "wss" : "ws"}://${node}/ws/file${
+        `${window.location.protocol === "https:" ? "wss" : "ws"}://${node}/ws/file${
             login ? `?token=${token}` : ""
         }`
     );
     fileSocket.onmessage = (e: MessageEvent) => {
-        if (typeof e.data == "string") {
+        if (typeof e.data === "string") {
             try {
                 let msg = JSON.parse(e.data);
                 if (msg.finished) {
@@ -81,7 +81,7 @@
         } else {
             currentSlices += 1;
             binData.push(e.data);
-            if (currentSlices == maxSlices) {
+            if (currentSlices === maxSlices) {
                 binURL = URL.createObjectURL(new Blob(binData));
                 maxSlices = 0;
                 currentSlices = 0;
@@ -93,9 +93,9 @@
     // Skip first array element (empty string)
     $: pathArray = currentPath.split("/").slice(1);
     // Set innerHTML manually to avoid issues with highlighting
-    $: fileDiv != undefined &&
+    $: fileDiv !== undefined &&
         (fileDiv.innerHTML = (
-            fileData[fileData.length - 1] == "\n" ? fileData + " " : fileData
+            fileData[fileData.length - 1] === "\n" ? fileData + " " : fileData
         )
             .replace(new RegExp("&", "g"), "&amp;")
             .replace(new RegExp("<", "g"), "&lt;")),
@@ -106,7 +106,7 @@
         });
 
     function sendCmd(path: string, cmd: string) {
-        if (cmd == "rm" || cmd == "rmdir" || cmd == "cd") {
+        if (cmd === "rm" || cmd === "rmdir" || cmd === "cd") {
             selPath = {
                 name: "",
                 path: "",
@@ -153,7 +153,7 @@
     }
 
     function checkTab(event: KeyboardEvent) {
-        if (event.key == "Tab") {
+        if (event.key === "Tab") {
             event.preventDefault();
 
             let startPos = fileText.selectionStart;
@@ -179,7 +179,7 @@
             case "audio":
                 return faFileAudio;
             case "archive":
-                if (subtype == "pdf") {
+                if (subtype === "pdf") {
                     return faFilePdf;
                 }
                 return faFileArchive;
@@ -195,13 +195,13 @@
     function validateInput(name: string | null) {
         if (name) {
             for (let element of socketData.contents) {
-                if (element.name == name) {
+                if (element.name === name) {
                     if (
                         confirm(
                             `This will overwrite the ${
-                                element.maintype == "dir" ? "directory" : "file"
+                                element.maintype === "dir" ? "directory" : "file"
                             } ${name}${
-                                element.maintype == "dir"
+                                element.maintype === "dir"
                                     ? " and delete everything in it"
                                     : ""
                             }. Are you sure you want to continue?`
@@ -209,7 +209,7 @@
                     ) {
                         sendCmd(
                             `${currentPath}/${name}`,
-                            `rm${element.maintype == "dir" ? "dir" : ""}`
+                            `rm${element.maintype === "dir" ? "dir" : ""}`
                         );
                         return true;
                     } else {
@@ -245,8 +245,8 @@
                     }}>/</button
                 >
                 {#each pathArray as path}
-                    {path != pathArray[0] ? " /" : ""}
-                    {#if path == pathArray[pathArray.length - 1]}
+                    {path !== pathArray[0] ? " /" : ""}
+                    {#if path === pathArray[pathArray.length - 1]}
                         <div class="inline-block cursor-default">
                             {path}
                         </div>
@@ -257,7 +257,7 @@
                                 let fullPath = "";
                                 for (let element of pathArray) {
                                     fullPath += "/" + element;
-                                    if (element == path) {
+                                    if (element === path) {
                                         break;
                                     }
                                 }
@@ -306,24 +306,24 @@
                     />
                 </div>
             {:else if downloading}
-                {#if binURL != ""}
+                {#if binURL !== ""}
                     <a
                         href={binURL}
                         target="_blank"
-                        download={selPath.maintype == "dir"
+                        download={selPath.maintype === "dir"
                             ? `${selPath.name}.zip`
                             : selPath.name}>Click to Download</a
                     >
-                {:else if maxSlices == 0}
+                {:else if maxSlices === 0}
                     <h2>
-                        {selPath.maintype == "dir"
+                        {selPath.maintype === "dir"
                             ? "Zipping directory"
                             : "Reading file"}...
                     </h2>
                 {:else}
                     <h2>Receiving {currentSlices}MB out of {maxSlices}MB</h2>
                 {/if}
-            {:else if socketData.contents != undefined}
+            {:else if socketData.contents !== undefined}
                 <table class="w-full bg-white table-fixed dark:bg-black min-w-50">
                     <tr>
                         <th class="px-2">Name</th>
@@ -336,7 +336,7 @@
                             contents.path
                                 ? ' !bg-dplime-dark'
                                 : ''}"
-                            class:hidden={!showHidden && contents.name[0] == "."}
+                            class:hidden={!showHidden && contents.name[0] === "."}
                             on:dblclick={() => {
                                 switch (contents.maintype) {
                                     case "dir":
@@ -385,7 +385,7 @@
                             >
                             <td class="px-2">{contents.prettytype}</td>
                             <td class="px-2"
-                                >{contents.maintype == "dir"
+                                >{contents.maintype === "dir"
                                     ? "-"
                                     : prettyBytes(contents.size)}</td
                             >
@@ -415,7 +415,7 @@
                         fileSend(currentPath, "save", fileData), (saved = true);
                     }}><Fa icon={faSave} size="lg" /></span
                 >
-            {:else if socketData.contents != undefined}
+            {:else if socketData.contents !== undefined}
                 <span
                     class="cursor-pointer"
                     title="Refresh"
@@ -429,7 +429,7 @@
                         showHidden = !showHidden;
                     }}><Fa icon={showHidden ? faEye : faEyeSlash} size="lg" /></span
                 >
-                {#if currentPath != "/"}
+                {#if currentPath !== "/"}
                     <span
                         class="cursor-pointer"
                         title="New Directory"
@@ -463,7 +463,7 @@
                             class="hidden"
                             bind:this={fileDialog}
                             on:input={() => {
-                                if (fileDialog.files != null) {
+                                if (fileDialog.files !== null) {
                                     let size = Math.ceil(
                                         fileDialog.files[0].size / (1000 * 1000)
                                     );
@@ -485,7 +485,7 @@
                             }}
                         /><Fa icon={faFileUpload} size="lg" /></span
                     >
-                    {#if selPath.path != "" && selPath.maintype != "notafile"}
+                    {#if selPath.path !== "" && selPath.maintype !== "notafile"}
                         <span
                             class="cursor-pointer"
                             title="Rename"
@@ -498,7 +498,7 @@
                                 }
                             }}><Fa icon={faICursor} size="lg" /></span
                         >
-                        {#if selPath.maintype != "dir"}
+                        {#if selPath.maintype !== "dir"}
                             <span
                                 class="cursor-pointer"
                                 title="Copy"
@@ -513,11 +513,11 @@
                                 if (
                                     confirm(
                                         `Are you sure you want to delete the ${
-                                            selPath.maintype == "dir"
+                                            selPath.maintype === "dir"
                                                 ? "directory"
                                                 : "file"
                                         } ${selPath.name}?${
-                                            selPath.maintype == "dir"
+                                            selPath.maintype === "dir"
                                                 ? " This will delete everything in it!"
                                                 : ""
                                         }`
@@ -525,7 +525,7 @@
                                 ) {
                                     sendCmd(
                                         selPath.path,
-                                        `rm${selPath.maintype == "dir" ? "dir" : ""}`
+                                        `rm${selPath.maintype === "dir" ? "dir" : ""}`
                                     );
                                 }
                             }}><Fa icon={faTrash} size="lg" /></span

--- a/frontend/src/pages/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser.svelte
@@ -60,12 +60,8 @@
     let binURL = "";
 
     const fileSocket = new WebSocket(
-        `${
-            window.location.protocol == "https:" ? "wss" : "ws"
-        }://${node}/ws/file${
-            login
-                ? `?token=${JSON.parse(localStorage.getItem("tokens"))[node]}`
-                : ""
+        `${window.location.protocol == "https:" ? "wss" : "ws"}://${node}/ws/file${
+            login ? `?token=${JSON.parse(localStorage.getItem("tokens"))[node]}` : ""
         }`
     );
     fileSocket.onmessage = (e: MessageEvent) => {
@@ -163,9 +159,7 @@
             let endPos = fileText.selectionEnd;
 
             let tabAdded =
-                fileData.substring(0, startPos) +
-                "\t" +
-                fileData.substring(endPos);
+                fileData.substring(0, startPos) + "\t" + fileData.substring(endPos);
 
             fileText.value = tabAdded;
             fileData = tabAdded;
@@ -294,9 +288,7 @@
                             saved = false;
                             if (fileText) {
                                 fileText.style.height = "auto";
-                                fileText.style.height = `${
-                                    fileText.scrollHeight + 10
-                                }px`;
+                                fileText.style.height = `${fileText.scrollHeight + 10}px`;
                                 fileDiv.style.height = "auto";
                             }
                         }}
@@ -331,9 +323,7 @@
                     <h2>Receiving {currentSlices}MB out of {maxSlices}MB</h2>
                 {/if}
             {:else if socketData.contents != undefined}
-                <table
-                    class="w-full bg-white table-fixed dark:bg-black min-w-50"
-                >
+                <table class="w-full bg-white table-fixed dark:bg-black min-w-50">
                     <tr>
                         <th class="px-2">Name</th>
                         <th class="px-2">Kind</th>
@@ -345,8 +335,7 @@
                             contents.path
                                 ? ' !bg-dplime-dark'
                                 : ''}"
-                            class:hidden={!showHidden &&
-                                contents.name[0] == "."}
+                            class:hidden={!showHidden && contents.name[0] == "."}
                             on:dblclick={() => {
                                 switch (contents.maintype) {
                                     case "dir":
@@ -360,11 +349,7 @@
                                                     "Can't view files above 2MB, would you like to download instead?"
                                                 )
                                             ) {
-                                                fileSend(
-                                                    selPath.path,
-                                                    "dl",
-                                                    ""
-                                                );
+                                                fileSend(selPath.path, "dl", "");
                                                 downloading = true;
                                             } else {
                                                 break;
@@ -393,14 +378,9 @@
                         >
                             <td class="px-2"
                                 ><Fa
-                                    icon={getIcon(
-                                        contents.maintype,
-                                        contents.subtype
-                                    )}
+                                    icon={getIcon(contents.maintype, contents.subtype)}
                                     class="mr-2"
-                                /><span class="break-words"
-                                    >{contents.name}</span
-                                ></td
+                                /><span class="break-words">{contents.name}</span></td
                             >
                             <td class="px-2">{contents.prettytype}</td>
                             <td class="px-2"
@@ -446,11 +426,7 @@
                     title="{showHidden ? 'Hide' : 'Show'} Hidden Files"
                     on:click={() => {
                         showHidden = !showHidden;
-                    }}
-                    ><Fa
-                        icon={showHidden ? faEye : faEyeSlash}
-                        size="lg"
-                    /></span
+                    }}><Fa icon={showHidden ? faEye : faEyeSlash} size="lg" /></span
                 >
                 {#if currentPath != "/"}
                     <span
@@ -469,9 +445,7 @@
                         class="cursor-pointer"
                         title="New File"
                         on:click={() => {
-                            let name = prompt(
-                                "Please enter the name of the new file"
-                            );
+                            let name = prompt("Please enter the name of the new file");
                             if (validateInput(name)) {
                                 sendCmd(`${currentPath}/${name}`, "mkfile");
                             }
@@ -502,10 +476,7 @@
                                     i += 1000 * 1000
                                 ) {
                                     fileSocket.send(
-                                        fileDialog.files[0].slice(
-                                            i,
-                                            i + 1000 * 1000
-                                        )
+                                        fileDialog.files[0].slice(i, i + 1000 * 1000)
                                     );
                                 }
                             }}
@@ -520,10 +491,7 @@
                                     "Please enter the new name of the file"
                                 );
                                 if (validateInput(name)) {
-                                    rename(
-                                        selPath.path,
-                                        `${currentPath}/${name}`
-                                    );
+                                    rename(selPath.path, `${currentPath}/${name}`);
                                 }
                             }}><Fa icon={faICursor} size="lg" /></span
                         >
@@ -554,11 +522,7 @@
                                 ) {
                                     sendCmd(
                                         selPath.path,
-                                        `rm${
-                                            selPath.maintype == "dir"
-                                                ? "dir"
-                                                : ""
-                                        }`
+                                        `rm${selPath.maintype == "dir" ? "dir" : ""}`
                                     );
                                 }
                             }}><Fa icon={faTrash} size="lg" /></span

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -181,7 +181,7 @@
                     scale: "deg",
                     values: (_: any, vals: number[]) =>
                         vals.map(
-                            (v: number) => +v + (tempUnit == "celsius" ? "ºC" : "ºF")
+                            (v: number) => +v + (tempUnit === "celsius" ? "ºC" : "ºF")
                         ),
                     grid: { show: false },
                     stroke: "#94A3B8",
@@ -199,7 +199,7 @@
 
         uplot = new uPlot(opts, data, chart);
 
-        if (socketData.swap.total == 0) {
+        if (socketData.swap.total === 0) {
             uplot.setSeries(3, { show: false });
         }
 
@@ -220,9 +220,9 @@
         dataPush[4].push(socketData.disk.used / 1000000);
         dataPush[5].push(socketData.network.sent / 1000000);
         dataPush[6].push(socketData.network.received / 1000000);
-        if (uplot != null) {
+        if (uplot !== null) {
             if (socketData.temp.available) {
-                if (uplot.series[7] == undefined) {
+                if (uplot.series[7] === undefined) {
                     uplot.addSeries({
                         spanGaps: false,
                         label: "CPU Temperature",
@@ -230,12 +230,12 @@
                         width: 3,
                         scale: "deg",
                         value: (_: any, val: number) =>
-                            val + (tempUnit == "celsius" ? "ºC" : "ºF"),
+                            val + (tempUnit === "celsius" ? "ºC" : "ºF"),
                     });
                 }
-                if (tempUnit == "celsius") {
+                if (tempUnit === "celsius") {
                     dataPush[7].push(socketData.temp.celsius);
-                } else if (tempUnit == "fahrenheit") {
+                } else if (tempUnit === "fahrenheit") {
                     dataPush[7].push(socketData.temp.fahrenheit);
                 }
             }

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -50,10 +50,7 @@
         prettyBytes(socketData.swap.used, { binary: true }),
         prettyBytes(socketData.swap.total, { binary: true }),
     ];
-    $: diskData = [
-        prettyBytes(socketData.disk.used),
-        prettyBytes(socketData.disk.total),
-    ];
+    $: diskData = [prettyBytes(socketData.disk.used), prettyBytes(socketData.disk.total)];
 
     function getTempMsg(temp: number) {
         if (temp >= 70) {
@@ -155,8 +152,7 @@
                     stroke: "#ec4899",
                     width: 3,
                     scale: "mb",
-                    value: (_: uPlot, val: number) =>
-                        prettyBytes(val * 1000000),
+                    value: (_: uPlot, val: number) => prettyBytes(val * 1000000),
                 },
             ],
             axes: [
@@ -185,8 +181,7 @@
                     scale: "deg",
                     values: (_: any, vals: number[]) =>
                         vals.map(
-                            (v: number) =>
-                                +v + (tempUnit == "celsius" ? "ºC" : "ºF")
+                            (v: number) => +v + (tempUnit == "celsius" ? "ºC" : "ºF")
                         ),
                     grid: { show: false },
                     stroke: "#94A3B8",
@@ -197,8 +192,7 @@
                 "%": {
                     auto: false,
                     // Hide CPU axis when CPU series is disabled
-                    range: (u: uPlot) =>
-                        u.series[1].show ? [0, 100] : [null, null],
+                    range: (u: uPlot) => (u.series[1].show ? [0, 100] : [null, null]),
                 },
             },
         };
@@ -269,8 +263,7 @@
         {#if socketData.temp.available}
             <div class="text-center">
                 <span class={getTempClass(socketData.temp.celsius)}>
-                    {socketData.temp.celsius}ºC/{socketData.temp
-                        .fahrenheit}ºF</span
+                    {socketData.temp.celsius}ºC/{socketData.temp.fahrenheit}ºF</span
                 >: {getTempMsg(socketData.temp.celsius)}
             </div>
             CPU:<span class="float-right">{socketData.cpu}/100%</span>

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -95,7 +95,7 @@
         });
     }
 
-    let uplot: uPlot;
+    let uplot: uPlot | null;
 
     onMount(() => {
         let opts: uPlot.Options = {
@@ -204,10 +204,11 @@
         }
 
         let observer = new ResizeObserver((entries, _) =>
-            resizeUplot(uplot, entries[0].target)
+            resizeUplot(uplot as uPlot, entries[0].target)
         );
 
-        observer.observe(document.getElementById("chart"));
+        // Guaranteed to exist
+        observer.observe(document.getElementById("chart") as HTMLElement);
     });
 
     let handle1 = setInterval(() => {
@@ -219,29 +220,31 @@
         dataPush[4].push(socketData.disk.used / 1000000);
         dataPush[5].push(socketData.network.sent / 1000000);
         dataPush[6].push(socketData.network.received / 1000000);
-        if (socketData.temp.available) {
-            if (uplot.series[7] == undefined) {
-                uplot.addSeries({
-                    spanGaps: false,
-                    label: "CPU Temperature",
-                    stroke: "#94A3B8",
-                    width: 3,
-                    scale: "deg",
-                    value: (_: any, val: number) =>
-                        val + (tempUnit == "celsius" ? "ºC" : "ºF"),
-                });
+        if (uplot != null) {
+            if (socketData.temp.available) {
+                if (uplot.series[7] == undefined) {
+                    uplot.addSeries({
+                        spanGaps: false,
+                        label: "CPU Temperature",
+                        stroke: "#94A3B8",
+                        width: 3,
+                        scale: "deg",
+                        value: (_: any, val: number) =>
+                            val + (tempUnit == "celsius" ? "ºC" : "ºF"),
+                    });
+                }
+                if (tempUnit == "celsius") {
+                    dataPush[7].push(socketData.temp.celsius);
+                } else if (tempUnit == "fahrenheit") {
+                    dataPush[7].push(socketData.temp.fahrenheit);
+                }
             }
-            if (tempUnit == "celsius") {
-                dataPush[7].push(socketData.temp.celsius);
-            } else if (tempUnit == "fahrenheit") {
-                dataPush[7].push(socketData.temp.fahrenheit);
-            }
+            uplot.setData(data);
         }
-        uplot.setData(data);
     }, 2000);
 
     onDestroy(() => {
-        uplot = undefined;
+        uplot = null;
         clearInterval(handle1);
     });
 </script>

--- a/frontend/src/pages/Management.svelte
+++ b/frontend/src/pages/Management.svelte
@@ -45,9 +45,7 @@
         </div>
     {/if}
     <Card header="System Information">
-        <table
-            class="border border-gray-100 dark:border-gray-900 h-full w-full"
-        >
+        <table class="border border-gray-100 dark:border-gray-900 h-full w-full">
             <tr
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >

--- a/frontend/src/pages/Management.svelte
+++ b/frontend/src/pages/Management.svelte
@@ -23,9 +23,9 @@
         setTimeout(() => {
             dialog = true;
         }, 1000);
-        if (data == "reboot") {
+        if (data === "reboot") {
             msg = "Waiting for device to finish...";
-        } else if (data == "poweroff") {
+        } else if (data === "poweroff") {
             msg = "You can close this page";
         }
     }

--- a/frontend/src/pages/Process.svelte
+++ b/frontend/src/pages/Process.svelte
@@ -223,42 +223,27 @@
         <tr class="table-header">
             <th
                 >PID<span on:click={setPid}
-                    ><Fa
-                        icon={pidIcon}
-                        class="float-right cursor-pointer"
-                    /></span
+                    ><Fa icon={pidIcon} class="float-right cursor-pointer" /></span
                 ></th
             >
             <th
                 >Name<span on:click={setName}
-                    ><Fa
-                        icon={nameIcon}
-                        class="float-right cursor-pointer"
-                    /></span
+                    ><Fa icon={nameIcon} class="float-right cursor-pointer" /></span
                 ></th
             >
             <th
                 >Status<span on:click={setStatus}
-                    ><Fa
-                        icon={statusIcon}
-                        class="float-right cursor-pointer"
-                    /></span
+                    ><Fa icon={statusIcon} class="float-right cursor-pointer" /></span
                 ></th
             >
             <th
                 >CPU Usage<span on:click={setCPU}
-                    ><Fa
-                        icon={cpuIcon}
-                        class="float-right cursor-pointer"
-                    /></span
+                    ><Fa icon={cpuIcon} class="float-right cursor-pointer" /></span
                 ></th
             >
             <th
                 >RAM Usage<span on:click={setRAM}
-                    ><Fa
-                        icon={ramIcon}
-                        class="float-right cursor-pointer"
-                    /></span
+                    ><Fa icon={ramIcon} class="float-right cursor-pointer" /></span
                 ></th
             >
             <th>Actions</th>
@@ -281,9 +266,7 @@
                     {#if process.name != "dietpi-dashboar"}
                         <span
                             on:click={() =>
-                                socketSend("terminate", [
-                                    process.pid.toString(),
-                                ])}
+                                socketSend("terminate", [process.pid.toString()])}
                             title="Terminate"
                             ><Fa
                                 icon={faBan}
@@ -292,8 +275,7 @@
                             /></span
                         >
                         <span
-                            on:click={() =>
-                                socketSend("kill", [process.pid.toString()])}
+                            on:click={() => socketSend("kill", [process.pid.toString()])}
                             title="Kill"
                             ><Fa
                                 icon={faSkull}
@@ -304,9 +286,7 @@
                         {#if process.status != "stopped"}
                             <span
                                 on:click={() =>
-                                    socketSend("suspend", [
-                                        process.pid.toString(),
-                                    ])}
+                                    socketSend("suspend", [process.pid.toString()])}
                                 title="Suspend"
                                 ><Fa
                                     icon={faPause}
@@ -317,9 +297,7 @@
                         {:else}
                             <span
                                 on:click={() =>
-                                    socketSend("resume", [
-                                        process.pid.toString(),
-                                    ])}
+                                    socketSend("resume", [process.pid.toString()])}
                                 title="Resume"
                                 ><Fa
                                     icon={faPlay}

--- a/frontend/src/pages/Process.svelte
+++ b/frontend/src/pages/Process.svelte
@@ -50,9 +50,9 @@
     }
 
     function setCPU() {
-        if (cpuSort == true) {
+        if (cpuSort === true) {
             reverse = !reverse;
-            if (cpuIcon == faSortUp) {
+            if (cpuIcon === faSortUp) {
                 cpuIcon = faSortDown;
             } else {
                 cpuIcon = faSortUp;
@@ -86,9 +86,9 @@
     }
 
     function setName() {
-        if (nameSort == true) {
+        if (nameSort === true) {
             reverse = !reverse;
-            if (nameIcon == faSortUp) {
+            if (nameIcon === faSortUp) {
                 nameIcon = faSortDown;
             } else {
                 nameIcon = faSortUp;
@@ -122,9 +122,9 @@
     }
 
     function setPid() {
-        if (pidSort == true) {
+        if (pidSort === true) {
             reverse = !reverse;
-            if (pidIcon == faSortUp) {
+            if (pidIcon === faSortUp) {
                 pidIcon = faSortDown;
             } else {
                 pidIcon = faSortUp;
@@ -158,9 +158,9 @@
     }
 
     function setRAM() {
-        if (ramSort == true) {
+        if (ramSort === true) {
             reverse = !reverse;
-            if (ramIcon == faSortUp) {
+            if (ramIcon === faSortUp) {
                 ramIcon = faSortDown;
             } else {
                 ramIcon = faSortUp;
@@ -194,9 +194,9 @@
     }
 
     function setStatus() {
-        if (statusSort == true) {
+        if (statusSort === true) {
             reverse = !reverse;
-            if (statusIcon == faSortUp) {
+            if (statusIcon === faSortUp) {
                 statusIcon = faSortDown;
             } else {
                 statusIcon = faSortUp;
@@ -263,7 +263,7 @@
                     })}</td
                 >
                 <td class="p-2 space-x-2">
-                    {#if process.name != "dietpi-dashboar"}
+                    {#if process.name !== "dietpi-dashboar"}
                         <span
                             on:click={() =>
                                 socketSend("terminate", [process.pid.toString()])}
@@ -283,7 +283,7 @@
                                 size="lg"
                             /></span
                         >
-                        {#if process.status != "stopped"}
+                        {#if process.status !== "stopped"}
                             <span
                                 on:click={() =>
                                     socketSend("suspend", [process.pid.toString()])}

--- a/frontend/src/pages/Service.svelte
+++ b/frontend/src/pages/Service.svelte
@@ -26,7 +26,7 @@
                 <td class="p-2">{service.name}</td>
                 <td class="p-2">{service.status}</td>
                 <td class="p-2">
-                    {#if service.log != ""}
+                    {#if service.log !== ""}
                         <details>
                             <summary> Show log </summary>
                             {@html service.log}
@@ -35,7 +35,7 @@
                 >
                 <td class="p-2">{service.start}</td>
                 <td class="p-2 space-x-2">
-                    {#if service.status == "inactive" || service.status == "failed"}
+                    {#if service.status === "inactive" || service.status === "failed"}
                         <span
                             on:click={() => socketSend("start", [service.name])}
                             title="Start"

--- a/frontend/src/pages/Service.svelte
+++ b/frontend/src/pages/Service.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-    import {
-        faSquare,
-        faPlay,
-        faRedoAlt,
-    } from "@fortawesome/free-solid-svg-icons";
+    import { faSquare, faPlay, faRedoAlt } from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
 
     import type { servicesPage } from "../types";
@@ -59,8 +55,7 @@
                                 size="lg"
                             /></span
                         ><span
-                            on:click={() =>
-                                socketSend("restart", [service.name])}
+                            on:click={() => socketSend("restart", [service.name])}
                             title="Restart"
                             ><Fa
                                 icon={faRedoAlt}

--- a/frontend/src/pages/Software.svelte
+++ b/frontend/src/pages/Software.svelte
@@ -56,9 +56,10 @@
             } else {
                 nameList += ", ";
             }
-            nameList += socketData[installTable ? "installed" : "uninstalled"].find(
-                o => o.id == installArray[i]
-            ).name;
+            nameList +=
+                socketData[installTable ? "installed" : "uninstalled"].find(
+                    o => o.id == installArray[i]
+                )?.name ?? "";
             if (i == installArray.length - 1) {
                 nameList += ")";
             }

--- a/frontend/src/pages/Software.svelte
+++ b/frontend/src/pages/Software.svelte
@@ -27,8 +27,7 @@
             installTemp = [];
             for (
                 let i = 0;
-                i <
-                socketData[installTable ? "installed" : "uninstalled"].length;
+                i < socketData[installTable ? "installed" : "uninstalled"].length;
                 i++
             ) {
                 installTemp[
@@ -42,9 +41,7 @@
 
     function checkButton() {
         installArray = [];
-        for (const i of socketData[
-            installTable ? "installed" : "uninstalled"
-        ]) {
+        for (const i of socketData[installTable ? "installed" : "uninstalled"]) {
             if (installTemp[i.id] == true) {
                 installArray = [...installArray, i.id];
             }
@@ -59,9 +56,9 @@
             } else {
                 nameList += ", ";
             }
-            nameList += socketData[
-                installTable ? "installed" : "uninstalled"
-            ].find((o) => o.id == installArray[i]).name;
+            nameList += socketData[installTable ? "installed" : "uninstalled"].find(
+                o => o.id == installArray[i]
+            ).name;
             if (i == installArray.length - 1) {
                 nameList += ")";
             }
@@ -71,7 +68,7 @@
     function sendSoftware() {
         socketSend(
             installTable ? "uninstall" : "install",
-            installArray.map((val) => {
+            installArray.map(val => {
                 return val.toString();
             })
         );
@@ -115,8 +112,7 @@
                         ><input
                             type="checkbox"
                             on:click={() =>
-                                (installTemp[software.id] =
-                                    !installTemp[software.id])}
+                                (installTemp[software.id] = !installTemp[software.id])}
                             bind:checked={installTemp[software.id]}
                             disabled={running}
                         /></td

--- a/frontend/src/pages/Software.svelte
+++ b/frontend/src/pages/Software.svelte
@@ -16,7 +16,7 @@
     // Runs once data is received or table is changed
     $: socketData.uninstalled && installTempCreate();
     $: socketData.uninstalled &&
-        installTable != undefined &&
+        installTable !== undefined &&
         ((needInstallTemp = true), installTempCreate());
 
     // Runs every time installTemp array is changed
@@ -42,7 +42,7 @@
     function checkButton() {
         installArray = [];
         for (const i of socketData[installTable ? "installed" : "uninstalled"]) {
-            if (installTemp[i.id] == true) {
+            if (installTemp[i.id] === true) {
                 installArray = [...installArray, i.id];
             }
         }
@@ -51,16 +51,16 @@
     function getNameList() {
         nameList = "";
         for (let i = 0; i < installArray.length; i++) {
-            if (i == 0) {
+            if (i === 0) {
                 nameList += " (";
             } else {
                 nameList += ", ";
             }
             nameList +=
                 socketData[installTable ? "installed" : "uninstalled"].find(
-                    o => o.id == installArray[i]
+                    o => o.id === installArray[i]
                 )?.name ?? "";
-            if (i == installArray.length - 1) {
+            if (i === installArray.length - 1) {
                 nameList += ")";
             }
         }
@@ -104,7 +104,7 @@
             <th>Documentation link</th>
         </tr>
         {#each socketData[installTable ? "installed" : "uninstalled"] as software}
-            {#if software.id != -1}
+            {#if software.id !== -1}
                 <tr
                     class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
                 >
@@ -122,7 +122,7 @@
                     <td class="p-2">{software.description}</td>
                     <td class="p-2">{software.dependencies}</td>
                     <td class="p-2">
-                        {#if software.docs.substring(0, 5) == "https"}
+                        {#if software.docs.substring(0, 5) === "https"}
                             <a
                                 href={software.docs}
                                 class="text-blue-500 underline"
@@ -144,7 +144,7 @@
             class="rounded border {installTable
                 ? 'bg-red-500 border-red-600 hover:bg-red-700'
                 : 'bg-green-500 border-green-600 hover:bg-green-700'} p-2 disabled:opacity-50"
-            disabled={installArray.length == 0 || running}
+            disabled={installArray.length === 0 || running}
         >
             {#if running}
                 <Fa icon={faCircleNotch} spin />
@@ -152,7 +152,7 @@
             {installTable ? "Uni" : "I"}nstall{nameList}
         </button>
     </div>
-    {#if socketData.response != ""}
+    {#if socketData.response !== ""}
         <textarea
             class="w-full bg-gray-200 h-72 rounded dark:bg-gray-800"
             value={socketData.response}

--- a/frontend/src/pages/Terminal.svelte
+++ b/frontend/src/pages/Terminal.svelte
@@ -10,7 +10,7 @@
 
     let termDiv: HTMLDivElement;
 
-    let proto = window.location.protocol == "https:" ? "wss" : "ws";
+    let proto = window.location.protocol === "https:" ? "wss" : "ws";
     let socket = new WebSocket(
         `${proto}://${node}/ws/term${token ? `?token=${token}` : ""}`
     );

--- a/frontend/src/pages/Terminal.svelte
+++ b/frontend/src/pages/Terminal.svelte
@@ -33,7 +33,7 @@
         socket.send(`size${size}`);
     };
 
-    terminal.onResize((e) => sendSize(e));
+    terminal.onResize(e => sendSize(e));
 
     window.onresize = () => {
         fitAddon.fit();

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,8 @@
      */
     "allowJs": true,
     "checkJs": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "strict": true
   },
   "include": [
     "src/**/*.d.ts",


### PR DESCRIPTION
*Part 1.5 of 3 to clean up frontend*

Actually install prettier in the devDependencies, and add a slightly modified config file.
Add Typescript 'strict' mode.
Replace `==` with `===`, and `!=` with `!==` in frontend. https://stackoverflow.com/questions/359494/which-equals-operator-vs-should-be-used-in-javascript-comparisons

Despite the branch name, I haven't actually added ESLint yet. Since I still have some major changes to do in the frontend, I'll probably add ESLint afterward to avoid fixing things now that I'm about to fix anyway.