### PR TITLE
refactor(frontend): use websocket store for sharing websocket between components

### DIFF
--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -5,4 +5,4 @@
     "arrowParens": "avoid",
     "printWidth": 90,
     "plugins": ["prettier-plugin-svelte"]
-  }
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -99,7 +99,6 @@
                 // Get token
                 if (login) {
                     if (tokens[node] === undefined) {
-                        console.debug("tokens[node]");
                         // Login
                         loginDialog = true;
                     } else {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -99,12 +99,14 @@
                 // Get token
                 if (login) {
                     if (tokens[node] === undefined) {
+                        console.debug("tokens[node]");
                         // Login
                         loginDialog = true;
                     } else {
                         // Or use stored token
                         token = tokens[node];
                         socket.send({ token });
+                        loginDialog = false;
                         pollServer(window.location.pathname);
                     }
                 } else {
@@ -313,13 +315,13 @@
         >
             {#if shown && $socket !== null}
                 <Router>
-                        <Route path="process"><Process /></Route>
-                        <Route path="/"><Home {darkMode} {tempUnit} /></Route>
-                        <Route path="software"><Software /></Route>
+                    <Route path="process"><Process /></Route>
+                    <Route path="/"><Home {darkMode} {tempUnit} /></Route>
+                    <Route path="software"><Software /></Route>
                     <Route path="terminal"><Terminal {node} {token} /></Route>
-                        <Route path="management"><Management /></Route>
+                    <Route path="management"><Management /></Route>
                     <Route path="browser"><FileBrowser {node} {login} {token} /></Route>
-                        <Route path="service"><Service /></Route>
+                    <Route path="service"><Service /></Route>
                     <Route path=""><h3>Page not found</h3></Route>
                 </Router>
             {:else}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -13,10 +13,8 @@
 
     import logo from "./assets/dietpi.png";
     import github from "./assets/github-mark.svg";
-    import type { socketData } from "./types";
+    import { socket } from "./websocket";
 
-    let socket: WebSocket;
-    let socketData: socketData;
     let nodes: string[] = [];
     let shown = false;
     let darkMode = false;
@@ -27,7 +25,6 @@
     let settingsShown = false;
     let passwordMessage = false;
     let notify = false;
-    let reopenSocket = true;
     let menu = window.innerWidth > 768;
     let dpUpdate = "";
     let tempUnit: "fahrenheit" | "celsius";
@@ -37,12 +34,12 @@
     let frontendVersion = __PACKAGE_VERSION__;
     let backendVersion = "";
     let updateAvailable = "";
-    let node = `${window.location.hostname}:${window.location.port}`;
+    let node = `${window.location.host}`;
     let tokens: Record<string, string> = JSON.parse(
         localStorage.getItem("tokens") ?? "{}"
     );
 
-    $: node && (((shown = false), (reopenSocket = false)), connectSocket(node));
+    $: $socket && (onSocketMessage(), (shown = true));
     $: notify =
         dpUpdate !== "" ||
         cmp(frontendVersion, backendVersion) !== 0 ||
@@ -88,72 +85,55 @@
         }
     };
 
-    const socketMessageListener = (e: MessageEvent) => {
-        socketData = JSON.parse(e.data);
-        if (socketData.dataKind === "GLOBAL") {
-            dpUpdate = socketData.update;
-            login = socketData.login;
-            if (socketData.nodes) {
-                nodes = socketData.nodes;
-            }
-            backendVersion = socketData.version;
-            tempUnit = socketData.temp_unit;
-            // Get token
-            if (login) {
-                if (tokens[node] === null) {
-                    // Login
-                    loginDialog = true;
+    function onSocketMessage() {
+        if ($socket) {
+            if ($socket.dataKind === "GLOBAL") {
+                dpUpdate = $socket.update;
+                login = $socket.login;
+                if ($socket.nodes) {
+                    nodes = $socket.nodes;
+                }
+                backendVersion = $socket.version;
+                tempUnit = $socket.temp_unit;
+                // Get token
+                if (login) {
+                    if (tokens[node] === null) {
+                        // Login
+                        loginDialog = true;
+                    } else {
+                        // Or use stored token
+                        token = tokens[node];
+                        socket.send({ token });
+                        pollServer(window.location.pathname);
+                    }
                 } else {
-                    // Or use stored token
-                    token = tokens[node];
-                    socket.send(JSON.stringify({ token }));
+                    // Remove legacy "token" setting
+                    localStorage.removeItem("token");
+                    localStorage.removeItem("tokens");
+                    token = "";
                     pollServer(window.location.pathname);
                 }
-            } else {
-                // Remove legacy "token" setting
-                localStorage.removeItem("token");
-                localStorage.removeItem("tokens");
-                token = "";
-                pollServer(window.location.pathname);
+                if ($socket.update_check) {
+                    updateCheck();
+                }
             }
-            if (socketData.update_check) {
-                updateCheck();
+            if ($socket.dataKind === "REAUTH") {
+                loginDialog = true;
+            }
+            if (navPage) {
+                blur = false;
+                navigate(navPage);
+                navPage = "";
             }
         }
-        if (socketData.dataKind === "REAUTH") {
-            loginDialog = true;
-        }
-        if (navPage) {
-            blur = false;
-            navigate(navPage);
-            navPage = "";
-        }
-    };
-    const socketOpenListener = () => {
-        console.info("Connected");
-        shown = true;
-        loginDialog = false;
-    };
-    const socketErrorListener = (e: Event) => {
-        console.error(e);
-    };
-    const socketCloseListener = (e: CloseEvent) => {
-        console.info("Disconnected, reconnecting:", reopenSocket);
-        if (reopenSocket) {
-            setTimeout(() => connectSocket(node), 1000);
-        } else {
-            reopenSocket = true;
-        }
-    };
+    }
 
     function pollServer(page: string) {
         if (page !== "/terminal") {
             // Terminal doesn't work if sent
-            socket.send(
-                JSON.stringify({
-                    page,
-                })
-            );
+            socket.send({
+                page,
+            });
         }
     }
 
@@ -183,33 +163,10 @@
                 tokens[node] = body;
                 localStorage.setItem("tokens", JSON.stringify(tokens));
                 loginDialog = false;
-                socket.send(JSON.stringify({ token }));
+                socket.send({ token });
                 pollServer(window.location.pathname);
             });
         });
-    }
-
-    function socketSend(cmd: string, args: string[]) {
-        socket.send(
-            JSON.stringify({
-                cmd,
-                args,
-            })
-        );
-    }
-
-    function connectSocket(url: string) {
-        if (socket) {
-            socket.close();
-        } else {
-            reopenSocket = true;
-        }
-        let proto = window.location.protocol === "https:" ? "wss" : "ws";
-        socket = new WebSocket(`${proto}://${url}/ws`);
-        socket.onopen = socketOpenListener;
-        socket.onmessage = socketMessageListener;
-        socket.onclose = socketCloseListener;
-        socket.onerror = socketErrorListener;
     }
 </script>
 
@@ -276,7 +233,7 @@
                         on:click={() => (settingsShown = !settingsShown)}
                     />
                 {/if}
-                {#if !notify}
+                {#if notify}
                     <button
                         on:click={() => (notificationsShown = !notificationsShown)}
                         class="flex"
@@ -353,41 +310,28 @@
             class="dark:bg-gray-900 bg-gray-100 flex-grow p-4 md:p-6 dark:text-white"
             class:blur-2={blur}
         >
-            {#if shown && socketData !== undefined}
+            {#if shown}
                 <Router>
-                    {#if socketData.dataKind === "PROCESS"}
-                        <Route path="process"><Process {socketData} {socketSend} /></Route
-                        >
+                    {#if $socket.dataKind === "PROCESS"}
+                        <Route path="process"><Process /></Route>
                     {/if}
-                    {#if socketData.dataKind === "STATISTIC"}
-                        <Route path="/"><Home {socketData} {darkMode} {tempUnit} /></Route
-                        >
+                    {#if $socket.dataKind === "STATISTIC"}
+                        <Route path="/"><Home {darkMode} {tempUnit} /></Route>
                     {/if}
-                    {#if socketData.dataKind === "SOFTWARE"}
-                        <Route path="software"
-                            ><Software {socketData} {socketSend} /></Route
-                        >
+                    {#if $socket.dataKind === "SOFTWARE"}
+                        <Route path="software"><Software /></Route>
                     {/if}
                     <Route path="terminal"><Terminal {node} {token} /></Route>
-                    {#if socketData.dataKind === "MANAGEMENT"}
-                        <Route path="management"
-                            ><Management {socketSend} {socketData} /></Route
-                        >
+                    {#if $socket.dataKind === "MANAGEMENT"}
+                        <Route path="management"><Management /></Route>
                     {/if}
-                    {#if socketData.dataKind === "BROWSER"}
+                    {#if $socket.dataKind === "BROWSER"}
                         <Route path="browser"
-                            ><FileBrowser
-                                {socketSend}
-                                {socketData}
-                                {node}
-                                {login}
-                                {token}
-                            /></Route
+                            ><FileBrowser {node} {login} {token} /></Route
                         >
                     {/if}
-                    {#if socketData.dataKind === "SERVICE"}
-                        <Route path="service"><Service {socketSend} {socketData} /></Route
-                        >
+                    {#if $socket.dataKind === "SERVICE"}
+                        <Route path="service"><Service /></Route>
                     {/if}
                     <Route path=""><h3>Page not found</h3></Route>
                 </Router>

--- a/frontend/src/pages/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser.svelte
@@ -2,9 +2,9 @@
     import microlight from "microlight";
     import prettyBytes from "pretty-bytes";
 
-    import { socket } from "../websocket";
+    import { browserStore } from "../websocket";
 
-    import type { browserPage, browserItem } from "../types";
+    import type { browserItem } from "../types";
 
     let selPath: browserItem = {
         name: "",
@@ -14,8 +14,6 @@
         prettytype: "",
         size: 0,
     };
-
-    $: socketData = $socket as browserPage;
 
     export let node: string;
     export let login: boolean;
@@ -78,8 +76,8 @@
             .replace(new RegExp("&", "g"), "&amp;")
             .replace(new RegExp("<", "g"), "&lt;")),
         microlight.reset();
-    $: socketData.contents &&
-        socketData.contents.sort((a, b) => {
+    $: $browserStore.contents &&
+        $browserStore.contents.sort((a, b) => {
             return a.name < b.name ? -1 : 1;
         });
 
@@ -94,7 +92,7 @@
                 size: 0,
             };
         }
-        socket.send({ cmd, args: [path] });
+        browserStore.send({ cmd, args: [path] });
         fileDataSet = false;
         if (downloading) {
             downloading = false;
@@ -122,7 +120,7 @@
             prettytype: "",
             size: 0,
         };
-        socket.send({ cmd: "rename", args: [oldname, newname] });
+        browserStore.send({ cmd: "rename", args: [oldname, newname] });
     }
 
     function syncScroll() {
@@ -172,7 +170,7 @@
 
     function validateInput(name: string | null) {
         if (name) {
-            for (let element of socketData.contents) {
+            for (let element of $browserStore.contents) {
                 if (element.name === name) {
                     if (
                         confirm(
@@ -301,14 +299,14 @@
                 {:else}
                     <h2>Receiving {currentSlices}MB out of {maxSlices}MB</h2>
                 {/if}
-            {:else if socketData.contents !== undefined}
+            {:else if $browserStore.contents !== undefined}
                 <table class="w-full bg-white table-fixed dark:bg-black min-w-50">
                     <tr>
                         <th class="px-2">Name</th>
                         <th class="px-2">Kind</th>
                         <th class="px-2">Size</th>
                     </tr>
-                    {#each socketData.contents as contents}
+                    {#each $browserStore.contents as contents}
                         <tr
                             class="select-none even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
                             class:!bg-dplime-dark={selPath.path == contents.path}
@@ -391,7 +389,7 @@
                         fileSend(currentPath, "save", fileData), (saved = true);
                     }}
                 />
-            {:else if socketData.contents !== undefined}
+            {:else if $browserStore.contents !== undefined}
                 <button
                     class="i-fa6-solid-rotate"
                     title="Refresh"

--- a/frontend/src/pages/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser.svelte
@@ -2,6 +2,8 @@
     import microlight from "microlight";
     import prettyBytes from "pretty-bytes";
 
+    import { socket } from "../websocket";
+
     import type { browserPage, browserItem } from "../types";
 
     let selPath: browserItem = {
@@ -13,8 +15,8 @@
         size: 0,
     };
 
-    export let socketSend: (cmd: string, args: string[]) => void;
-    export let socketData: browserPage;
+    $: socketData = $socket as browserPage;
+
     export let node: string;
     export let login: boolean;
     export let token: string;
@@ -92,7 +94,7 @@
                 size: 0,
             };
         }
-        socketSend(cmd, [path]);
+        socket.send({ cmd, args: [path] });
         fileDataSet = false;
         if (downloading) {
             downloading = false;
@@ -120,7 +122,7 @@
             prettytype: "",
             size: 0,
         };
-        socketSend("rename", [oldname, newname]);
+        socket.send({ cmd: "rename", args: [oldname, newname] });
     }
 
     function syncScroll() {

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -6,9 +6,14 @@
     import "uplot/dist/uPlot.min.css";
     import { onMount, onDestroy } from "svelte";
 
+    import { socket } from "../websocket";
+
     import type { statisticsPage } from "../types";
 
-    export let socketData: statisticsPage;
+    $: console.debug($socket);
+    $: $socket.dataKind == "STATISTIC" && (socketData = $socket as statisticsPage);
+
+    let socketData: statisticsPage;
     export let darkMode: boolean;
     export let tempUnit: "fahrenheit" | "celsius";
 

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -88,16 +88,18 @@
     }
 
     function resizeUplot(uplot: uPlot, entry: Element) {
-        uplot.setSize({
-            width: Math.min(
-                entry.clientWidth - 10,
-                (window.innerWidth / 100) * (portrait ? 70 : 50)
-            ),
-            height: Math.min(
-                entry.clientHeight - 20,
-                (window.innerHeight / 100) * (portrait ? 50 : 70)
-            ),
-        });
+        if (uplot !== null) {
+            uplot.setSize({
+                width: Math.min(
+                    entry.clientWidth - 10,
+                    (window.innerWidth / 100) * (portrait ? 70 : 50)
+                ),
+                height: Math.min(
+                    entry.clientHeight - 20,
+                    (window.innerHeight / 100) * (portrait ? 50 : 70)
+                ),
+            });
+        }
     }
 
     let uplot: uPlot | null;

--- a/frontend/src/pages/Management.svelte
+++ b/frontend/src/pages/Management.svelte
@@ -3,10 +3,11 @@
     import prettyMilliseconds from "pretty-ms";
     import { fade } from "svelte/transition";
 
+    import { socket } from "../websocket";
+
     import type { managementPage } from "../types";
 
-    export let socketSend: (cmd: string, args: string[]) => void;
-    export let socketData: managementPage;
+    $: socketData = $socket as managementPage;
 
     let uptime: string;
     let dialog = false;
@@ -18,7 +19,7 @@
         (dialog = false);
 
     function sendData(data: string) {
-        socketSend(data, []);
+        socket.send({ cmd: data, args: [] });
         // Give backend an extra second to loop again
         setTimeout(() => {
             dialog = true;

--- a/frontend/src/pages/Management.svelte
+++ b/frontend/src/pages/Management.svelte
@@ -3,23 +3,19 @@
     import prettyMilliseconds from "pretty-ms";
     import { fade } from "svelte/transition";
 
-    import { socket } from "../websocket";
-
-    import type { managementPage } from "../types";
-
-    $: socketData = $socket as managementPage;
+    import { managementStore } from "../websocket";
 
     let uptime: string;
     let dialog = false;
     let msg = "";
 
-    $: (uptime = prettyMilliseconds(socketData.uptime * 60000, {
+    $: (uptime = prettyMilliseconds($managementStore.uptime * 60000, {
         verbose: true,
     })),
         (dialog = false);
 
     function sendData(data: string) {
-        socket.send({ cmd: data, args: [] });
+        managementStore.send({ cmd: data, args: [] });
         // Give backend an extra second to loop again
         setTimeout(() => {
             dialog = true;
@@ -51,19 +47,19 @@
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >
                 <td class="p-1 font-semibold">Hostname:</td>
-                <td class="p-1">{socketData.hostname}</td>
+                <td class="p-1">{$managementStore.hostname}</td>
             </tr>
             <tr
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >
                 <td class="p-1 font-semibold">Network Interface:</td>
-                <td class="p-1">{socketData.nic}</td>
+                <td class="p-1">{$managementStore.nic}</td>
             </tr>
             <tr
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >
                 <td class="p-1 font-semibold">IP Address:</td>
-                <td class="p-1">{socketData.ip}</td>
+                <td class="p-1">{$managementStore.ip}</td>
             </tr>
             <tr
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
@@ -75,27 +71,27 @@
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >
                 <td class="p-1 font-semibold">Kernel:</td>
-                <td class="p-1">{socketData.kernel}</td>
+                <td class="p-1">{$managementStore.kernel}</td>
             </tr>
             <tr
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >
                 <td class="p-1 font-semibold">Architecture:</td>
-                <td class="p-1">{socketData.arch}</td>
+                <td class="p-1">{$managementStore.arch}</td>
             </tr>
             <tr
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >
                 <td class="p-1 font-semibold">Version:</td>
-                <td class="p-1">{socketData.dp_version}</td>
+                <td class="p-1">{$managementStore.dp_version}</td>
             </tr>
             <tr
                 class="even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800"
             >
                 <td class="p-1 font-semibold">Installed Packages:</td>
                 <td class="p-1"
-                    >{socketData.packages}
-                    {#if socketData.upgrades !== 0}({socketData.upgrades} upgradable){/if}
+                    >{$managementStore.packages}
+                    {#if $managementStore.upgrades !== 0}({$managementStore.upgrades} upgradable){/if}
                 </td>
             </tr>
         </table>

--- a/frontend/src/pages/Process.svelte
+++ b/frontend/src/pages/Process.svelte
@@ -3,8 +3,9 @@
 
     import { processStore } from "../websocket";
 
-    import type { processPage, processItem } from "../types";
+    import type { processItem } from "../types";
 
+    $: processes = $processStore.processes;
     // Sorts when $processStore, sortBy, or reverse updates
     $: $processStore.processes, sortBy, reverse, sortTable(sortBy);
 
@@ -14,7 +15,7 @@
     $: console.log(reverse);
 
     function sortTable(sortValue: keyof processItem) {
-        $processStore.processes.sort((a, b) => {
+        processes.sort((a, b) => {
             if (a[sortValue] > b[sortValue]) {
                 return reverse ? -1 : 1;
             } else if (a[sortValue] < b[sortValue]) {
@@ -22,7 +23,7 @@
             }
             return 0;
         });
-        $processStore.processes = $processStore.processes;
+        processes = processes;
     }
 
     function resortTable(sortValue: keyof processItem) {
@@ -107,7 +108,7 @@
             </th>
             <th>Actions</th>
         </tr>
-        {#each $processStore.processes as process}
+        {#each processes as process}
             <tr
                 class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
             >

--- a/frontend/src/pages/Process.svelte
+++ b/frontend/src/pages/Process.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
     import prettyBytes from "pretty-bytes";
 
-    import { socket } from "../websocket";
+    import { processStore } from "../websocket";
 
     import type { processPage, processItem } from "../types";
 
-    $: socketData = $socket as processPage;
-
-    // Sorts when socketData, sortBy, or reverse updates
-    $: socketData.processes, sortBy, reverse, sortTable(sortBy);
+    // Sorts when $processStore, sortBy, or reverse updates
+    $: $processStore.processes, sortBy, reverse, sortTable(sortBy);
 
     let sortBy: keyof processItem = "pid";
     let reverse = false;
@@ -16,7 +14,7 @@
     $: console.log(reverse);
 
     function sortTable(sortValue: keyof processItem) {
-        socketData.processes.sort((a, b) => {
+        $processStore.processes.sort((a, b) => {
             if (a[sortValue] > b[sortValue]) {
                 return reverse ? -1 : 1;
             } else if (a[sortValue] < b[sortValue]) {
@@ -24,7 +22,7 @@
             }
             return 0;
         });
-        socketData.processes = socketData.processes;
+        $processStore.processes = $processStore.processes;
     }
 
     function resortTable(sortValue: keyof processItem) {
@@ -109,7 +107,7 @@
             </th>
             <th>Actions</th>
         </tr>
-        {#each socketData.processes as process}
+        {#each $processStore.processes as process}
             <tr
                 class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
             >
@@ -128,7 +126,7 @@
                         <button
                             class="rounded-sm p-0.5 btn i-fa6-solid-ban text-2xl"
                             on:click={() =>
-                                socket.send({
+                                processStore.send({
                                     cmd: "terminate",
                                     args: [process.pid.toString()],
                                 })}
@@ -137,7 +135,7 @@
                         <button
                             class="rounded-sm p-0.5 btn i-fa6-solid-skull text-2xl"
                             on:click={() =>
-                                socket.send({
+                                processStore.send({
                                     cmd: "kill",
                                     args: [process.pid.toString()],
                                 })}
@@ -147,7 +145,7 @@
                             <button
                                 class="rounded-sm p-0.5 btn i-fa6-solid-pause text-2xl"
                                 on:click={() =>
-                                    socket.send({
+                                    processStore.send({
                                         cmd: "suspend",
                                         args: [process.pid.toString()],
                                     })}
@@ -157,7 +155,7 @@
                             <button
                                 class="rounded-sm p-0.5 btn i-fa6-solid-play text-2xl"
                                 on:click={() =>
-                                    socket.send({
+                                    processStore.send({
                                         cmd: "resume",
                                         args: [process.pid.toString()],
                                     })}

--- a/frontend/src/pages/Process.svelte
+++ b/frontend/src/pages/Process.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
     import prettyBytes from "pretty-bytes";
 
+    import { socket } from "../websocket";
+
     import type { processPage, processItem } from "../types";
 
-    export let socketData: processPage;
-    export let socketSend: (cmd: string, args: string[]) => void;
+    $: socketData = $socket as processPage;
 
     // Sorts when socketData, sortBy, or reverse updates
     $: socketData.processes, sortBy, reverse, sortTable(sortBy);
@@ -127,26 +128,39 @@
                         <button
                             class="rounded-sm p-0.5 btn i-fa6-solid-ban text-2xl"
                             on:click={() =>
-                                socketSend("terminate", [process.pid.toString()])}
+                                socket.send({
+                                    cmd: "terminate",
+                                    args: [process.pid.toString()],
+                                })}
                             title="Terminate"
                         />
                         <button
                             class="rounded-sm p-0.5 btn i-fa6-solid-skull text-2xl"
-                            on:click={() => socketSend("kill", [process.pid.toString()])}
+                            on:click={() =>
+                                socket.send({
+                                    cmd: "kill",
+                                    args: [process.pid.toString()],
+                                })}
                             title="Kill"
                         />
                         {#if process.status != "stopped"}
                             <button
                                 class="rounded-sm p-0.5 btn i-fa6-solid-pause text-2xl"
                                 on:click={() =>
-                                    socketSend("suspend", [process.pid.toString()])}
+                                    socket.send({
+                                        cmd: "suspend",
+                                        args: [process.pid.toString()],
+                                    })}
                                 title="Suspend"
                             />
                         {:else}
                             <button
                                 class="rounded-sm p-0.5 btn i-fa6-solid-play text-2xl"
                                 on:click={() =>
-                                    socketSend("resume", [process.pid.toString()])}
+                                    socket.send({
+                                        cmd: "resume",
+                                        args: [process.pid.toString()],
+                                    })}
                                 title="Resume"
                             />
                         {/if}

--- a/frontend/src/pages/Service.svelte
+++ b/frontend/src/pages/Service.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
     import type { servicesPage } from "../types";
 
-    export let socketSend: (cmd: string, args: string[]) => void;
-    export let socketData: servicesPage;
+    import { socket } from "../websocket";
+
+    $: socketData = $socket as servicesPage;
 </script>
 
 <main>
@@ -34,17 +35,20 @@
                 <td class="p-2 space-x-2">
                     {#if service.status === "inactive" || service.status === "failed"}
                         <button
-                            on:click={() => socketSend("start", [service.name])}
+                            on:click={() =>
+                                socket.send({ cmd: "start", args: [service.name] })}
                             title="Start"
                             class="btn rounded-sm p-0.5 i-fa6-solid-play text-2xl"
                         />
                     {:else}
                         <button
-                            on:click={() => socketSend("stop", [service.name])}
+                            on:click={() =>
+                                socket.send({ cmd: "stop", args: [service.name] })}
                             title="Stop"
                             class="btn rounded-sm p-0.5 i-fa6-solid-square text-2xl"
                         /><button
-                            on:click={() => socketSend("restart", [service.name])}
+                            on:click={() =>
+                                socket.send({ cmd: "restart", args: [service.name] })}
                             title="Restart"
                             class="btn rounded-sm p-0.5 i-fa6-solid-rotate-left text-2xl"
                         />

--- a/frontend/src/pages/Service.svelte
+++ b/frontend/src/pages/Service.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-    import type { servicesPage } from "../types";
-
-    import { socket } from "../websocket";
-
-    $: socketData = $socket as servicesPage;
+    import { serviceStore } from "../websocket";
 </script>
 
 <main>
@@ -17,7 +13,7 @@
             <th>Start Time</th>
             <th>Actions</th>
         </tr>
-        {#each socketData.services as service}
+        {#each $serviceStore.services as service}
             <tr
                 class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
             >
@@ -36,19 +32,22 @@
                     {#if service.status === "inactive" || service.status === "failed"}
                         <button
                             on:click={() =>
-                                socket.send({ cmd: "start", args: [service.name] })}
+                                serviceStore.send({ cmd: "start", args: [service.name] })}
                             title="Start"
                             class="btn rounded-sm p-0.5 i-fa6-solid-play text-2xl"
                         />
                     {:else}
                         <button
                             on:click={() =>
-                                socket.send({ cmd: "stop", args: [service.name] })}
+                                serviceStore.send({ cmd: "stop", args: [service.name] })}
                             title="Stop"
                             class="btn rounded-sm p-0.5 i-fa6-solid-square text-2xl"
                         /><button
                             on:click={() =>
-                                socket.send({ cmd: "restart", args: [service.name] })}
+                                serviceStore.send({
+                                    cmd: "restart",
+                                    args: [service.name],
+                                })}
                             title="Restart"
                             class="btn rounded-sm p-0.5 i-fa6-solid-rotate-left text-2xl"
                         />

--- a/frontend/src/pages/Software.svelte
+++ b/frontend/src/pages/Software.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
     import type { softwarePage } from "../types";
 
-    export let socketData: softwarePage;
-    export let socketSend: (cmd: string, args: string[]) => void;
+    import { socket } from "../websocket";
+
+    $: socketData = $socket as softwarePage;
 
     let installTemp: boolean[] = [];
     let installArray: number[] = [];
@@ -65,12 +66,12 @@
     }
 
     function sendSoftware() {
-        socketSend(
-            installTable ? "uninstall" : "install",
-            installArray.map(val => {
+        socket.send({
+            cmd: installTable ? "uninstall" : "install",
+            args: installArray.map(val => {
                 return val.toString();
-            })
-        );
+            }),
+        });
         running = true;
     }
 </script>

--- a/frontend/src/pages/Software.svelte
+++ b/frontend/src/pages/Software.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-    import type { softwarePage } from "../types";
-
-    import { socket } from "../websocket";
-
-    $: socketData = $socket as softwarePage;
+    import { softwareStore } from "../websocket";
 
     let installTemp: boolean[] = [];
     let installArray: number[] = [];
@@ -13,24 +9,24 @@
     let nameList = "";
 
     // Runs once data is received or table is changed
-    $: socketData.uninstalled && installTempCreate();
-    $: socketData.uninstalled &&
+    $: $softwareStore.uninstalled && installTempCreate();
+    $: $softwareStore.uninstalled &&
         installTable !== undefined &&
         ((needInstallTemp = true), installTempCreate());
 
     // Runs every time installTemp array is changed
-    $: socketData.uninstalled && installTemp && (checkButton(), getNameList());
+    $: $softwareStore.uninstalled && installTemp && (checkButton(), getNameList());
 
     const installTempCreate = () => {
         if (needInstallTemp) {
             installTemp = [];
             for (
                 let i = 0;
-                i < socketData[installTable ? "installed" : "uninstalled"].length;
+                i < $softwareStore[installTable ? "installed" : "uninstalled"].length;
                 i++
             ) {
                 installTemp[
-                    socketData[installTable ? "installed" : "uninstalled"][i].id
+                    $softwareStore[installTable ? "installed" : "uninstalled"][i].id
                 ] = false;
             }
         }
@@ -40,7 +36,7 @@
 
     function checkButton() {
         installArray = [];
-        for (const i of socketData[installTable ? "installed" : "uninstalled"]) {
+        for (const i of $softwareStore[installTable ? "installed" : "uninstalled"]) {
             if (installTemp[i.id] === true) {
                 installArray = [...installArray, i.id];
             }
@@ -56,7 +52,7 @@
                 nameList += ", ";
             }
             nameList +=
-                socketData[installTable ? "installed" : "uninstalled"].find(
+                $softwareStore[installTable ? "installed" : "uninstalled"].find(
                     o => o.id === installArray[i]
                 )?.name ?? "";
             if (i === installArray.length - 1) {
@@ -66,7 +62,7 @@
     }
 
     function sendSoftware() {
-        socket.send({
+        softwareStore.send({
             cmd: installTable ? "uninstall" : "install",
             args: installArray.map(val => {
                 return val.toString();
@@ -102,7 +98,7 @@
             <th>Dependencies</th>
             <th>Documentation link</th>
         </tr>
-        {#each socketData[installTable ? "installed" : "uninstalled"] as software}
+        {#each $softwareStore[installTable ? "installed" : "uninstalled"] as software}
             {#if software.id !== -1}
                 <tr
                     class="mt-32 even:bg-white odd:bg-gray-200 dark:even:bg-black dark:odd:bg-gray-800  dark:border-gray-600 border-t-2 border-gray-300 border-opacity-50"
@@ -151,10 +147,10 @@
             {installTable ? "Uni" : "I"}nstall{nameList}
         </button>
     </div>
-    {#if socketData.response !== ""}
+    {#if $softwareStore.response !== ""}
         <textarea
             class="w-full bg-gray-200 h-72 rounded dark:bg-gray-800"
-            value={socketData.response}
+            value={$softwareStore.response}
             disabled
         />
     {/if}

--- a/frontend/src/pages/Software.svelte
+++ b/frontend/src/pages/Software.svelte
@@ -147,7 +147,7 @@
             {installTable ? "Uni" : "I"}nstall{nameList}
         </button>
     </div>
-    {#if $softwareStore.response !== ""}
+    {#if $softwareStore.response}
         <textarea
             class="w-full bg-gray-200 h-72 rounded dark:bg-gray-800"
             value={$softwareStore.response}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -66,7 +66,6 @@ interface globalSettings {
 
 interface reauthenticate {
     dataKind: "REAUTH";
-    reauth: true;
 }
 
 interface softwareItem {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,7 +22,7 @@ interface softwarePage {
     dataKind: "SOFTWARE";
     uninstalled: softwareItem[];
     installed: softwareItem[];
-    response: string;
+    response?: string;
 }
 
 interface processPage {
@@ -129,5 +129,5 @@ export type {
     managementPage,
     globalSettings,
     browserItem,
-    processItem
+    processItem,
 };

--- a/frontend/src/websocket.ts
+++ b/frontend/src/websocket.ts
@@ -51,6 +51,7 @@ function createWebsocketStore(host: string) {
         if (socket) {
             socket.removeEventListener("open", onOpen);
             socket.removeEventListener("close", onClose);
+            socket.removeEventListener("error", onClose);
             socket.removeEventListener("message", onMessage);
             socket.close();
         }
@@ -65,6 +66,7 @@ function createWebsocketStore(host: string) {
 
         socket.addEventListener("open", onOpen);
         socket.addEventListener("close", onClose);
+        socket.addEventListener("error", onClose);
         socket.addEventListener("message", onMessage);
     }
 

--- a/frontend/src/websocket.ts
+++ b/frontend/src/websocket.ts
@@ -139,8 +139,6 @@ export const softwareStore = createStore<softwarePage>({
     dataKind: "SOFTWARE",
     installed: [],
     uninstalled: [],
-    // TODO: make response optional
-    response: "",
 });
 
 export const managementStore = createStore<managementPage>({

--- a/frontend/src/websocket.ts
+++ b/frontend/src/websocket.ts
@@ -1,21 +1,29 @@
-import type { socketData } from "./types";
+import type {
+    browserPage,
+    managementPage,
+    processPage,
+    servicesPage,
+    socketData,
+    softwarePage,
+    statisticsPage,
+} from "./types";
+import { derived } from "svelte/store";
 
-type request =
-    | { page: string }
-    | { cmd: string; args?: string[] }
-    | { token: string };
+type request = { page: string } | { cmd: string; args?: string[] } | { token: string };
 
 // Inspired by the svelte-websocket-store package
 function createWebsocketStore(host: string) {
     let socket: WebSocket | undefined;
-    const subscribers: Set<(value: socketData | {dataKind: "NOTCONNECTED"}) => void> = new Set();
+    const subscribers: Set<(value: socketData | { dataKind: "NOTCONNECTED" }) => void> =
+        new Set();
     let reopenTimeout: ReturnType<typeof setTimeout> | undefined;
     let retryCount = 0;
     let proto = window.location.protocol === "http:" ? "ws" : "wss";
     let lastValue: socketData | undefined;
 
-    function subscribe(callback: (value: socketData | {dataKind: "NOTCONNECTED"}) => void): () => void {
-        console.debug("new subscriber");
+    function subscribe(
+        callback: (value: socketData | { dataKind: "NOTCONNECTED" }) => void
+    ): () => void {
         subscribers.add(callback);
         if (lastValue) {
             callback(lastValue);
@@ -29,7 +37,7 @@ function createWebsocketStore(host: string) {
         if (socket && socket.readyState === WebSocket.OPEN) {
             socket.send(JSON.stringify(message));
         } else {
-            console.error('WebSocket is not connected');
+            console.error("WebSocket is not connected");
         }
     }
 
@@ -44,9 +52,9 @@ function createWebsocketStore(host: string) {
         clearTimeout(reopenTimeout);
 
         if (socket) {
-            socket.removeEventListener('open', onOpen);
-            socket.removeEventListener('close', onClose);
-            socket.removeEventListener('message', onMessage);
+            socket.removeEventListener("open", onOpen);
+            socket.removeEventListener("close", onClose);
+            socket.removeEventListener("message", onMessage);
             socket.close();
         }
 
@@ -58,18 +66,18 @@ function createWebsocketStore(host: string) {
 
         socket = new WebSocket(newUrl);
 
-        socket.addEventListener('open', onOpen);
-        socket.addEventListener('close', onClose);
-        socket.addEventListener('message', onMessage);
+        socket.addEventListener("open", onOpen);
+        socket.addEventListener("close", onClose);
+        socket.addEventListener("message", onMessage);
     }
 
     function onOpen() {
-        console.log('WebSocket connected');
+        console.log("WebSocket connected");
         retryCount = 0;
     }
 
     function onClose() {
-        console.log('WebSocket disconnected');
+        console.log("WebSocket disconnected");
         if (!reopenTimeout) {
             const delay = Math.pow(2, retryCount) * 1000;
             retryCount++;
@@ -80,7 +88,7 @@ function createWebsocketStore(host: string) {
     function onMessage(event: MessageEvent) {
         const data = JSON.parse(event.data);
         lastValue = data;
-        subscribers.forEach((callback) => {
+        subscribers.forEach(callback => {
             callback(data);
         });
     }
@@ -90,5 +98,66 @@ function createWebsocketStore(host: string) {
     return { subscribe, send, reopen };
 }
 
-
 export const socket = createWebsocketStore(window.location.host);
+
+// Creates a derived store that filters the WebSocket data by `dataKind`
+function createStore<T extends socketData>(defaultValue: T) {
+    const store = derived(socket, $socket => {
+        let lastValue = defaultValue;
+        if ($socket.dataKind == defaultValue.dataKind) {
+            lastValue = $socket as T;
+        }
+        return lastValue;
+    });
+    return { ...store, send: socket.send };
+}
+
+// Gives each page a separate store that either holds a default value or the last value given by the websocket
+export const statisticsStore = createStore<statisticsPage>({
+    dataKind: "STATISTIC",
+    cpu: 0,
+    disk: { used: 0, total: 0, percent: 0 },
+    ram: { used: 0, total: 0, percent: 0 },
+    network: { sent: 0, received: 0 },
+    swap: { used: 0, total: 0, percent: 0 },
+    // TODO: modify so that { available: false } and { available: true, celsius: 0, fahrenheit: 32 }
+    // is possible, there shouldn't have to be values if it isn't available
+    temp: { celsius: 0, fahrenheit: 0, available: false },
+});
+
+export const processStore = createStore<processPage>({
+    dataKind: "PROCESS",
+    processes: [],
+});
+
+export const serviceStore = createStore<servicesPage>({
+    dataKind: "SERVICE",
+    services: [],
+});
+
+export const softwareStore = createStore<softwarePage>({
+    dataKind: "SOFTWARE",
+    installed: [],
+    uninstalled: [],
+    // TODO: make response optional
+    response: "",
+});
+
+export const managementStore = createStore<managementPage>({
+    dataKind: "MANAGEMENT",
+    hostname: "unknown",
+    uptime: 0,
+    arch: "unknown",
+    kernel: "unknown",
+    dp_version: "unknown",
+    packages: 0,
+    upgrades: 0,
+    nic: "unknown",
+    ip: "127.0.0.1",
+});
+
+export const browserStore = createStore<browserPage>({
+    dataKind: "BROWSER",
+    contents: [],
+    textdata: "",
+});

--- a/frontend/src/websocket.ts
+++ b/frontend/src/websocket.ts
@@ -14,16 +14,13 @@ type request = { page: string } | { cmd: string; args?: string[] } | { token: st
 // Inspired by the svelte-websocket-store package
 function createWebsocketStore(host: string) {
     let socket: WebSocket | undefined;
-    const subscribers: Set<(value: socketData | { dataKind: "NOTCONNECTED" }) => void> =
-        new Set();
+    const subscribers: Set<(value: socketData | null) => void> = new Set();
     let reopenTimeout: ReturnType<typeof setTimeout> | undefined;
     let retryCount = 0;
     let proto = window.location.protocol === "http:" ? "ws" : "wss";
     let lastValue: socketData | undefined;
 
-    function subscribe(
-        callback: (value: socketData | { dataKind: "NOTCONNECTED" }) => void
-    ): () => void {
+    function subscribe(callback: (value: socketData | null) => void): () => void {
         subscribers.add(callback);
         if (lastValue) {
             callback(lastValue);
@@ -104,7 +101,7 @@ export const socket = createWebsocketStore(window.location.host);
 function createStore<T extends socketData>(defaultValue: T) {
     const store = derived(socket, $socket => {
         let lastValue = defaultValue;
-        if ($socket.dataKind == defaultValue.dataKind) {
+        if ($socket && $socket.dataKind == defaultValue.dataKind) {
             lastValue = $socket as T;
         }
         return lastValue;

--- a/frontend/src/websocket.ts
+++ b/frontend/src/websocket.ts
@@ -1,0 +1,94 @@
+import type { socketData } from "./types";
+
+type request =
+    | { page: string }
+    | { cmd: string; args?: string[] }
+    | { token: string };
+
+// Inspired by the svelte-websocket-store package
+function createWebsocketStore(host: string) {
+    let socket: WebSocket | undefined;
+    const subscribers: Set<(value: socketData | {dataKind: "NOTCONNECTED"}) => void> = new Set();
+    let reopenTimeout: ReturnType<typeof setTimeout> | undefined;
+    let retryCount = 0;
+    let proto = window.location.protocol === "http:" ? "ws" : "wss";
+    let lastValue: socketData | undefined;
+
+    function subscribe(callback: (value: socketData | {dataKind: "NOTCONNECTED"}) => void): () => void {
+        console.debug("new subscriber");
+        subscribers.add(callback);
+        if (lastValue) {
+            callback(lastValue);
+        }
+        return () => {
+            subscribers.delete(callback);
+        };
+    }
+
+    function send(message: request): void {
+        if (socket && socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify(message));
+        } else {
+            console.error('WebSocket is not connected');
+        }
+    }
+
+    function scheduleReconnect(delay: number) {
+        console.log(`WebSocket connection lost. Retrying in ${delay / 1000} seconds...`);
+        reopenTimeout = setTimeout(() => {
+            reopen();
+        }, delay);
+    }
+
+    function reopen(newHost?: string): void {
+        clearTimeout(reopenTimeout);
+
+        if (socket) {
+            socket.removeEventListener('open', onOpen);
+            socket.removeEventListener('close', onClose);
+            socket.removeEventListener('message', onMessage);
+            socket.close();
+        }
+
+        if (newHost) {
+            host = newHost;
+        }
+
+        let newUrl = `${proto}://${host}/ws`;
+
+        socket = new WebSocket(newUrl);
+
+        socket.addEventListener('open', onOpen);
+        socket.addEventListener('close', onClose);
+        socket.addEventListener('message', onMessage);
+    }
+
+    function onOpen() {
+        console.log('WebSocket connected');
+        retryCount = 0;
+    }
+
+    function onClose() {
+        console.log('WebSocket disconnected');
+        if (!reopenTimeout) {
+            const delay = Math.pow(2, retryCount) * 1000;
+            retryCount++;
+            scheduleReconnect(delay);
+        }
+    }
+
+    function onMessage(event: MessageEvent) {
+        const data = JSON.parse(event.data);
+        lastValue = data;
+        subscribers.forEach((callback) => {
+            callback(data);
+        });
+    }
+
+    reopen();
+
+    return { subscribe, send, reopen };
+}
+
+
+export const socket = createWebsocketStore(window.location.host);

--- a/src/page_handlers.rs
+++ b/src/page_handlers.rs
@@ -147,7 +147,7 @@ pub async fn software_handler_helper(
     Ok(shared::DPSoftwareList {
         uninstalled: software.0,
         installed: software.1,
-        response: out,
+        response: Some(out),
     })
 }
 
@@ -158,7 +158,7 @@ pub async fn software_handler(socket_send: &mut SocketSend, data_recv: &mut Recv
         .send(shared::BackendData::Software(shared::DPSoftwareList {
             uninstalled: software.0,
             installed: software.1,
-            response: String::new(),
+            response: None,
         }))
         .await
         .is_err()

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -263,9 +263,14 @@ where
 pub async fn router(req: Request<Body>, span: tracing::Span) -> anyhow::Result<Response<Body>> {
     let mut response = Response::new(Body::empty());
 
+    let mut path = req.uri().path();
+    if path != "/" {
+        path = path.trim_end_matches('/');
+    }
+
     match (
         req.method(),
-        req.uri().path(),
+        path,
         // Make a String to avoid lifetime errors
         req.uri().query().map(str::to_string),
     ) {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -92,7 +92,7 @@ pub enum BackendData {
     Service(ServiceList),
     Global(GlobalData),
     Browser(BrowserList),
-    Reauth { reauth: bool },
+    Reauth,
 }
 
 #[derive(Serialize, Default)]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -160,7 +160,8 @@ pub struct DPSoftwareData {
 pub struct DPSoftwareList {
     pub installed: Vec<DPSoftwareData>,
     pub uninstalled: Vec<DPSoftwareData>,
-    pub response: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<String>,
 }
 
 #[derive(Serialize, Default)]

--- a/src/socket_handlers.rs
+++ b/src/socket_handlers.rs
@@ -155,11 +155,7 @@ pub async fn socket_handler(
                 "/login" => {
                     tracing::debug!("Sending login message");
                     // Internal poll, see other thread
-                    if socket_send
-                        .send(shared::BackendData::Reauth)
-                        .await
-                        .is_err()
-                    {
+                    if socket_send.send(shared::BackendData::Reauth).await.is_err() {
                         break;
                     }
                     false

--- a/src/socket_handlers.rs
+++ b/src/socket_handlers.rs
@@ -156,7 +156,7 @@ pub async fn socket_handler(
                     tracing::debug!("Sending login message");
                     // Internal poll, see other thread
                     if socket_send
-                        .send(shared::BackendData::Reauth { reauth: true })
+                        .send(shared::BackendData::Reauth)
                         .await
                         .is_err()
                     {


### PR DESCRIPTION
*Part 2 of 3 to clean up frontend* 
Instead of the websocket being created in the `App` component and passed through props, it is instead created as a Svelte store that each component can import. In addition, derived stores are created so that each component always has a value ready-to-go, either a default or the last value received. This doesn't add much right now, but it will soon.