### PR TITLE
chore(backend): apply clippy suggestion

### DIFF
--- a/src/page_handlers.rs
+++ b/src/page_handlers.rs
@@ -98,7 +98,7 @@ pub async fn process_handler(socket_send: &mut SocketSend, data_recv: &mut RecvC
         tokio::select! {
             biased;
             data = data_recv.recv() => match data {
-                Some(Some(RequestTypes::Cmd { cmd, args: Some(args) })) => handle_error!(process_handler_helper(&cmd, args.get(0).map(String::as_str))),
+                Some(Some(RequestTypes::Cmd { cmd, args: Some(args) })) => handle_error!(process_handler_helper(&cmd, args.first().map(String::as_str))),
                 Some(Some(_)) => {}
                 _ => return false,
             },
@@ -232,7 +232,7 @@ pub async fn service_handler(socket_send: &mut SocketSend, data_recv: &mut RecvC
             args: Some(args),
         } = data
         {
-            if let Some(arg) = args.get(0) {
+            if let Some(arg) = args.first() {
                 handle_error!(Command::new("systemctl")
                     .args([&cmd, arg])
                     .spawn()
@@ -270,7 +270,7 @@ async fn browser_handler_helper(cmd: &str, args: &[String]) -> anyhow::Result<sh
 
     tracing::debug!("Command is {}", cmd);
 
-    if let Some(arg) = args.get(0) {
+    if let Some(arg) = args.first() {
         match cmd {
             "cd" => {
                 return Ok(shared::BrowserList {

--- a/src/socket_handlers.rs
+++ b/src/socket_handlers.rs
@@ -48,6 +48,7 @@ fn validate_token(token: &str, fingerprint: Option<&str>) -> TokenState {
 }
 
 #[instrument(skip_all)]
+#[allow(clippy::no_effect_underscore_binding)]
 pub async fn socket_handler(
     socket: tokio_tungstenite::WebSocketStream<hyper::upgrade::Upgraded>,
     fingerprint: Option<String>,


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#/get_first
https://rust-lang.github.io/rust-clippy/master/index.html#/no_effect_underscore_binding

These seem to break https://nightly.link/.

I am not 100% sure whether the `token` argument in `socket_handler` is really unused? As far as I understand, it is, respectively it is overwritten with `String::new()` and probably some remain from the token handling change, and the token is now obtained within `socket_handler`?

EDIT: Okay, at last the websocket connections pass a token to this function:
```rust
            if let Some(token) = token {
                response = websocket(
                    req,
                    crate::socket_handlers::term_handler,
                    span,
                    token.to_string(),
                )?;
```
So since I am not 100% sure whether I understand the code correctly, Instead the warning is not ignored.