### PR TITLE
chore(deps): migrate to @xterm modules

### DIFF
--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Enable pnpm
         run: corepack enable
       - uses: taiki-e/install-action@v2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@unocss/reset": "^0.65.0",
+    "@xterm/addon-attach": "^0.11.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "microlight": "^0.0.7",
     "pretty-bytes": "^6.1.0",
     "pretty-ms": "^9.0.0",
     "semver-compare-multi": "^1.0.3",
-    "uplot": "^1.6.24",
-    "xterm": "^5.1.0",
-    "xterm-addon-attach": "^0.9.0",
-    "xterm-addon-fit": "^0.8.0"
+    "uplot": "^1.6.24"
   },
   "packageManager": "pnpm@9.15.4"
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@unocss/reset':
         specifier: ^0.65.0
         version: 0.65.4
+      '@xterm/addon-attach':
+        specifier: ^0.11.0
+        version: 0.11.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       microlight:
         specifier: ^0.0.7
         version: 0.0.7
@@ -26,15 +35,6 @@ importers:
       uplot:
         specifier: ^1.6.24
         version: 1.6.31
-      xterm:
-        specifier: ^5.1.0
-        version: 5.3.0
-      xterm-addon-attach:
-        specifier: ^0.9.0
-        version: 0.9.0(xterm@5.3.0)
-      xterm-addon-fit:
-        specifier: ^0.8.0
-        version: 0.8.0(xterm@5.3.0)
     devDependencies:
       '@iconify-json/fa6-solid':
         specifier: ^1.1.12
@@ -855,6 +855,19 @@ packages:
   '@vue/shared@3.5.12':
     resolution: {integrity: sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==}
 
+  '@xterm/addon-attach@0.11.0':
+    resolution: {integrity: sha512-JboCN0QAY6ZLY/SSB/Zl2cQ5zW1Eh4X3fH7BnuR1NB7xGRhzbqU2Npmpiw/3zFlxDaU88vtKzok44JKi2L2V2Q==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
@@ -1542,22 +1555,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  xterm-addon-attach@0.9.0:
-    resolution: {integrity: sha512-NykWWOsobVZPPK3P9eFkItrnBK9Lw0f94uey5zhqIVB1bhswdVBfl+uziEzSOhe2h0rT9wD0wOeAYsdSXeavPw==}
-    deprecated: This package is now deprecated. Move to @xterm/addon-attach instead.
-    peerDependencies:
-      xterm: ^5.0.0
-
-  xterm-addon-fit@0.8.0:
-    resolution: {integrity: sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==}
-    deprecated: This package is now deprecated. Move to @xterm/addon-fit instead.
-    peerDependencies:
-      xterm: ^5.0.0
-
-  xterm@5.3.0:
-    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
-    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
-
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -2171,6 +2168,16 @@ snapshots:
       vue: 3.5.12(typescript@5.7.3)
 
   '@vue/shared@3.5.12': {}
+
+  '@xterm/addon-attach@0.11.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
 
   acorn@8.14.0: {}
 
@@ -2882,13 +2889,3 @@ snapshots:
       typescript: 5.7.3
 
   wrappy@1.0.2: {}
-
-  xterm-addon-attach@0.9.0(xterm@5.3.0):
-    dependencies:
-      xterm: 5.3.0
-
-  xterm-addon-fit@0.8.0(xterm@5.3.0):
-    dependencies:
-      xterm: 5.3.0
-
-  xterm@5.3.0: {}

--- a/frontend/src/pages/Terminal.svelte
+++ b/frontend/src/pages/Terminal.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import { Terminal } from "xterm";
-    import { AttachAddon } from "xterm-addon-attach";
-    import { FitAddon, type ITerminalDimensions } from "xterm-addon-fit";
-    import "xterm/css/xterm.css";
+    import { Terminal } from "@xterm/xterm";
+    import { AttachAddon } from "@xterm/addon-attach";
+    import { FitAddon, type ITerminalDimensions } from "@xterm/addon-fit";
+    import "@xterm/xterm/css/xterm.css";
 
     import { onDestroy } from "svelte";
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => {
         input: "src/main.ts",
         output: {
           manualChunks: {
-            xterm: ["xterm", "xterm-addon-attach", "xterm-addon-fit"],
+            xterm: ["@xterm/xterm", "@xterm/addon-attach", "@xterm/addon-fit"],
           },
         },
       },


### PR DESCRIPTION
Addons by the core team are now developed in the main repo: https://github.com/xtermjs/xterm-addon-attach

Works all fine, Terminal page looks and works exactly like before, so this did not imply any breaking changes.