### PR TITLE
chore(frontend): remove unsed Ipv6Addr import

### DIFF
--- a/crates/frontend/src/backend/mod.rs
+++ b/crates/frontend/src/backend/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     sync::{Arc, Mutex},
 };
 

--- a/crates/frontend/src/http/mod.rs
+++ b/crates/frontend/src/http/mod.rs
@@ -1,4 +1,4 @@
-use std::net::{Ipv6Addr, SocketAddr};
+use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
 use auth::SharedLoginMap;


### PR DESCRIPTION
Or is this somehow indirectly used? Though if so, I'd assume `Ipv4Addr` to be required explicitly as well.